### PR TITLE
Fix SELinux rules from the NeoZygisk side

### DIFF
--- a/module/src/sepolicy.rule
+++ b/module/src/sepolicy.rule
@@ -6,13 +6,12 @@ allow zygote magisk lnk_file read
 allow zygote unlabeled file {read open}
 allow zygote zygote capability sys_chroot
 allow zygote su dir search
-allow zygote su lnk_file read
-allow zygote su file read
+allow zygote su {lnk_file file} read
 
 allow zygote adb_data_file dir search
 allow zygote zygote process execmem
 allow system_server system_server process execmem
 allow zygote tmpfs file *
 
-allow zygote mnt_vendor_file dir search
-allow zygote fs_type filesystem unmount
+allow {installd isolated_app shell} magisk_file {file dir} *
+allow zygote appdomain_tmpfs file *


### PR DESCRIPTION
Even though https://github.com/JingMatrix/LSPosed/pull/143 has added missing SELinux rules from the LSPosed. It seems that different root implementations might load rules in different orders, which could be a source of problem. To avoid such cases, we'd better fix SELinux rules from the NeoZygisk side.

We deleted the original block of rules for unmounting, since current implementation of DenyList is based on the chroot permission. The two added rules for LSPosed are found using SELinux logs:
```
adb shell su -c setenforce 0 && adb shell su -c 'cat /proc/kmsg | grep avc'
```

Some rules are rewritten equivalently.

Note: Even though the SELinux context magisk_file is protected by DAC, we still prefer to be cautious and conservative by not adding the rule `allow * magisk_file {file dir} *` directly.