### PR TITLE
Fix compatibility with hardened_malloc

### DIFF
--- a/loader/src/ptracer/monitor.cpp
+++ b/loader/src/ptracer/monitor.cpp
@@ -144,8 +144,7 @@ struct SocketHandler : public EventHandler {
             char data[0];
         };
         for (;;) {
-            std::vector<uint8_t> buf;
-            buf.resize(sizeof(MsgHead), 0);
+            std::vector<uint8_t> buf(sizeof(MsgHead), 0);
             MsgHead &msg = *reinterpret_cast<MsgHead *>(buf.data());
             ssize_t real_size;
             auto nread = recv(sock_fd_, &msg, sizeof(msg), MSG_PEEK);


### PR DESCRIPTION
DivestOS users reported that vector::resize might trigger `hardened_malloc` fatal error: detected write after free. We move it to the initialization of `buf` to avoid this error.