### PR TITLE
Fix hardened_malloc error

### DIFF
--- a/loader/src/ptracer/monitor.cpp
+++ b/loader/src/ptracer/monitor.cpp
@@ -144,8 +144,7 @@ struct SocketHandler : public EventHandler {
             char data[0];
         };
         for (;;) {
-            std::vector<uint8_t> buf;
-            buf.resize(sizeof(MsgHead), 0);
+            std::vector<uint8_t> buf(sizeof(MsgHead), 0);
             MsgHead &msg = *reinterpret_cast<MsgHead *>(buf.data());
             ssize_t real_size;
             auto nread = recv(sock_fd_, &msg, sizeof(msg), MSG_PEEK);
@@ -247,6 +246,7 @@ struct SocketHandler : public EventHandler {
                 LOGD("system server started, module.prop updated");
                 break;
             }
+            break;
         }
     }
 

--- a/loader/src/ptracer/monitor.cpp
+++ b/loader/src/ptracer/monitor.cpp
@@ -146,7 +146,7 @@ struct SocketHandler : public EventHandler {
         int read_count = 0;
         void *buf = malloc(sizeof(MsgHead));
         for (;;) {
-            LOGD("reading from %d: %d", sock_fd_, read_count++);
+            LOGD("reading from %d to %p: %d", sock_fd_, buf, read_count++);
             MsgHead &msg = *reinterpret_cast<MsgHead *>(buf);
             ssize_t real_size;
             auto nread = recv(sock_fd_, &msg, sizeof(msg), MSG_PEEK);
@@ -227,24 +227,24 @@ struct SocketHandler : public EventHandler {
                 break;
             case DAEMON64_SET_INFO:
                 LOGD("received daemon64 info %s", msg.data);
-                status64.daemon_info = std::string(msg.data);
+                status64.daemon_info = std::string(strdup(msg.data));
                 updateStatus();
                 break;
             case DAEMON32_SET_INFO:
                 LOGD("received daemon32 info %s", msg.data);
-                status32.daemon_info = std::string(msg.data);
+                status32.daemon_info = std::string(strdup(msg.data));
                 updateStatus();
                 break;
             case DAEMON64_SET_ERROR_INFO:
                 LOGD("received daemon64 error info %s", msg.data);
                 status64.daemon_running = false;
-                status64.daemon_error_info = std::string(msg.data);
+                status64.daemon_error_info = std::string(strdup(msg.data));
                 updateStatus();
                 break;
             case DAEMON32_SET_ERROR_INFO:
                 LOGD("received daemon32 error info %s", msg.data);
                 status32.daemon_running = false;
-                status32.daemon_error_info = std::string(msg.data);
+                status32.daemon_error_info = std::string(strdup(msg.data));
                 updateStatus();
                 break;
             case SYSTEM_SERVER_STARTED:

--- a/loader/src/ptracer/monitor.cpp
+++ b/loader/src/ptracer/monitor.cpp
@@ -143,13 +143,16 @@ struct SocketHandler : public EventHandler {
             int length;
             char data[0];
         };
+        int read_count = 0;
         for (;;) {
+            LOGD("reading from %d: %d", sock_fd_, read_count++);
             std::vector<uint8_t> buf(sizeof(MsgHead), 0);
             MsgHead &msg = *reinterpret_cast<MsgHead *>(buf.data());
             ssize_t real_size;
             auto nread = recv(sock_fd_, &msg, sizeof(msg), MSG_PEEK);
             if (nread == -1) {
                 if (errno == EAGAIN) {
+                    LOGD("end of socket %d", sock_fd_);
                     break;
                 }
                 PLOGE("read socket");
@@ -176,6 +179,7 @@ struct SocketHandler : public EventHandler {
             nread = recv(sock_fd_, &msg, real_size, 0);
             if (nread == -1) {
                 if (errno == EAGAIN) {
+                    LOGD("failed to read %zd bytes socket %d", real_size, sock_fd_);
                     break;
                 }
                 PLOGE("recv");


### PR DESCRIPTION
DivestOS users reported that vector::resize might trigger `hardened_malloc fatal error: detected write after free`.
From the error message, this can only happen when the for loop is executed for multiple times.
Note that the for loop is effective only when data to read still exist in the socket queue, which is the case when we call `recv` with flag MSG_PEEK.
Hence, after we call `recv` with zero flags, which consume data in the socket queue, we should break the for loop.

Note: previously, we break the for loop according to errno == EAGAIN.

As a simplification, we also move the resize call to the initialization of buf.