### PR TITLE
Avoid racing issue of creating clean mount profile

### DIFF
--- a/loader/src/common/daemon.cpp
+++ b/loader/src/common/daemon.cpp
@@ -15,8 +15,9 @@ std::string GetTmpPath() { return TMP_PATH; }
 
 int Connect(uint8_t retry) {
     int fd = socket(PF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
-    struct sockaddr_un addr {
-        .sun_family = AF_UNIX, .sun_path = {0},
+    struct sockaddr_un addr{
+        .sun_family = AF_UNIX,
+        .sun_path = {0},
     };
     auto socket_path = TMP_PATH + kCPSocketName;
     strcpy(addr.sun_path, socket_path.c_str());
@@ -52,9 +53,17 @@ uint32_t GetProcessFlags(uid_t uid) {
         return 0;
     }
     socket_utils::write_u8(fd, (uint8_t) SocketAction::GetProcessFlags);
-    socket_utils::write_u32(fd, (uint32_t) getpid());
     socket_utils::write_u32(fd, uid);
     return socket_utils::read_u32(fd);
+}
+
+void CacheMountNamespace(pid_t pid) {
+    UniqueFd fd = Connect(1);
+    if (fd == -1) {
+        PLOGE("CacheMountNamespace");
+    }
+    socket_utils::write_u8(fd, (uint8_t) SocketAction::CacheMountNamespace);
+    socket_utils::write_u32(fd, (uint32_t) pid);
 }
 
 std::string UpdateMountNamespace(MountNamespace type) {
@@ -64,7 +73,6 @@ std::string UpdateMountNamespace(MountNamespace type) {
         return "";
     }
     socket_utils::write_u8(fd, (uint8_t) SocketAction::UpdateMountNamespace);
-    socket_utils::write_u32(fd, (uint32_t) getpid());
     socket_utils::write_u8(fd, (uint8_t) type);
     uint32_t target_pid = socket_utils::read_u32(fd);
     int target_fd = (int) socket_utils::read_u32(fd);

--- a/loader/src/common/daemon.cpp
+++ b/loader/src/common/daemon.cpp
@@ -52,18 +52,19 @@ uint32_t GetProcessFlags(uid_t uid) {
         return 0;
     }
     socket_utils::write_u8(fd, (uint8_t) SocketAction::GetProcessFlags);
+    socket_utils::write_u32(fd, (uint32_t) getpid());
     socket_utils::write_u32(fd, uid);
     return socket_utils::read_u32(fd);
 }
 
-std::string UpdateMountNamespace(pid_t pid, MountNamespace type) {
+std::string UpdateMountNamespace(MountNamespace type) {
     UniqueFd fd = Connect(1);
     if (fd == -1) {
         PLOGE("UpdateMountNamespace");
         return "";
     }
     socket_utils::write_u8(fd, (uint8_t) SocketAction::UpdateMountNamespace);
-    socket_utils::write_u32(fd, (uint32_t) pid);
+    socket_utils::write_u32(fd, (uint32_t) getpid());
     socket_utils::write_u8(fd, (uint8_t) type);
     uint32_t target_pid = socket_utils::read_u32(fd);
     int target_fd = (int) socket_utils::read_u32(fd);

--- a/loader/src/include/daemon.hpp
+++ b/loader/src/include/daemon.hpp
@@ -58,6 +58,7 @@ struct Module {
 enum class SocketAction {
     PingHeartbeat,
     GetProcessFlags,
+    CacheMountNamespace,
     UpdateMountNamespace,
     ReadModules,
     RequestCompanionSocket,
@@ -77,6 +78,8 @@ bool PingHeartbeat();
 std::vector<Module> ReadModules();
 
 uint32_t GetProcessFlags(uid_t uid);
+
+void CacheMountNamespace(pid_t pid);
 
 std::string UpdateMountNamespace(MountNamespace type);
 

--- a/loader/src/include/daemon.hpp
+++ b/loader/src/include/daemon.hpp
@@ -78,7 +78,7 @@ std::vector<Module> ReadModules();
 
 uint32_t GetProcessFlags(uid_t uid);
 
-std::string UpdateMountNamespace(pid_t pid, MountNamespace type);
+std::string UpdateMountNamespace(MountNamespace type);
 
 int ConnectCompanion(size_t index);
 

--- a/loader/src/injector/hook.cpp
+++ b/loader/src/injector/hook.cpp
@@ -106,9 +106,9 @@ DCL_HOOK_FUNC(static int, unshare, int flags) {
         // Skip system server and the first app process since we don't need to hide traces for them
         !(g_ctx->flags & SERVER_FORK_AND_SPECIALIZE) && !(g_ctx->info_flags & IS_FIRST_PROCESS)) {
         if (g_ctx->info_flags & (PROCESS_IS_MANAGER | PROCESS_GRANTED_ROOT)) {
-            ZygiskContext::update_mount_namespace(getpid(), zygiskd::MountNamespace::Root);
+            ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Root);
         } else if (!(g_ctx->flags & DO_REVERT_UNMOUNT)) {
-            ZygiskContext::update_mount_namespace(getpid(), zygiskd::MountNamespace::Module);
+            ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Module);
         }
         old_unshare(CLONE_NEWNS);
     }

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -327,6 +327,9 @@ void ZygiskContext::app_specialize_pre() {
     flags |= APP_SPECIALIZE;
 
     info_flags = zygiskd::GetProcessFlags(g_ctx->args.app->uid);
+    if (info_flags & IS_FIRST_PROCESS) {
+        zygiskd::CacheMountNamespace(getpid());
+    }
     if ((info_flags & UNMOUNT_MASK) == UNMOUNT_MASK) {
         LOGI("[%s] is on the denylist\n", process);
         flags |= DO_REVERT_UNMOUNT;

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -327,9 +327,6 @@ void ZygiskContext::app_specialize_pre() {
     flags |= APP_SPECIALIZE;
 
     info_flags = zygiskd::GetProcessFlags(g_ctx->args.app->uid);
-    if (info_flags & IS_FIRST_PROCESS) {
-        update_mount_namespace(getpid(), zygiskd::MountNamespace::Clean, true);
-    }
     if ((info_flags & UNMOUNT_MASK) == UNMOUNT_MASK) {
         LOGI("[%s] is on the denylist\n", process);
         flags |= DO_REVERT_UNMOUNT;
@@ -397,7 +394,7 @@ void ZygiskContext::nativeForkAndSpecialize_pre() {
     flags |= APP_FORK_AND_SPECIALIZE;
 
     // unmount the root implementation for Zygote
-    update_mount_namespace(getpid(), zygiskd::MountNamespace::Clean, false);
+    update_mount_namespace(zygiskd::MountNamespace::Clean);
 
     fork_pre();
     if (is_child()) {
@@ -416,19 +413,12 @@ void ZygiskContext::nativeForkAndSpecialize_post() {
 
 // -----------------------------------------------------------------
 
-bool ZygiskContext::update_mount_namespace(pid_t pid, zygiskd::MountNamespace namespace_type,
-                                           bool dry_run) {
-    if (pid < 0) {
-        LOGD("update mount namespace with an invalid pid %d", pid);
-        return false;
-    }
-
-    std::string ns_path = zygiskd::UpdateMountNamespace(pid, namespace_type);
+bool ZygiskContext::update_mount_namespace(zygiskd::MountNamespace namespace_type) {
+    std::string ns_path = zygiskd::UpdateMountNamespace(namespace_type);
     if (!ns_path.starts_with("/proc/")) {
         PLOGE("update mount namespace [%s]", ns_path.data());
         return false;
     }
-    if (dry_run) return true;
 
     auto updated_ns = open(ns_path.data(), O_RDONLY);
     if (updated_ns >= 0) {

--- a/loader/src/injector/module.hpp
+++ b/loader/src/injector/module.hpp
@@ -310,8 +310,7 @@ struct ZygiskContext {
 
     bool plt_hook_commit();
 
-    static bool update_mount_namespace(pid_t pid, zygiskd::MountNamespace namespace_type,
-                                       bool dry_run = false);
+    static bool update_mount_namespace(zygiskd::MountNamespace namespace_type);
 };
 
 #undef DCL_PRE_POST

--- a/loader/src/injector/zygisk.hpp
+++ b/loader/src/injector/zygisk.hpp
@@ -5,8 +5,6 @@
 
 void hook_entry(void *start_addr, size_t block_size);
 
-bool update_mnt_ns(pid_t pid, bool clean, bool dry_run = false);
-
 void hookJniNativeMethods(JNIEnv *env, const char *clz, JNINativeMethod *methods, int numMethods);
 
 void clean_trace(const char *path, size_t load, size_t unload, bool spoof_maps);

--- a/zygiskd/src/constants.rs
+++ b/zygiskd/src/constants.rs
@@ -27,6 +27,7 @@ pub const SYSTEM_SERVER_STARTED: i32 = 10;
 pub enum DaemonSocketAction {
     PingHeartbeat,
     GetProcessFlags,
+    CacheMountNamespace,
     UpdateMountNamespace,
     ReadModules,
     RequestCompanionSocket,

--- a/zygiskd/src/constants.rs
+++ b/zygiskd/src/constants.rs
@@ -35,7 +35,7 @@ pub enum DaemonSocketAction {
     SystemServerStarted,
 }
 
-#[derive(Debug, Eq, PartialEq, TryFromPrimitive, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
 pub enum MountNamespace {
     Clean,

--- a/zygiskd/src/constants.rs
+++ b/zygiskd/src/constants.rs
@@ -35,7 +35,7 @@ pub enum DaemonSocketAction {
     SystemServerStarted,
 }
 
-#[derive(Debug, Eq, PartialEq, TryFromPrimitive)]
+#[derive(Debug, Eq, PartialEq, TryFromPrimitive, Clone, Copy)]
 #[repr(u8)]
 pub enum MountNamespace {
     Clean,

--- a/zygiskd/src/utils.rs
+++ b/zygiskd/src/utils.rs
@@ -141,7 +141,16 @@ pub fn save_mount_namespace(pid: i32, namespace_type: MountNamespace) -> Result<
         MountNamespace::Root => ROOT_MNT_NS_FD.initiated(),
         MountNamespace::Module => MODULE_MNT_NS_FD.initiated(),
     };
+
     if !is_initialized {
+        if pid == -1 {
+            bail!(
+                "mount profiles not fully cached: {}, {}, {}",
+                CLEAN_MNT_NS_FD.initiated(),
+                ROOT_MNT_NS_FD.initiated(),
+                MODULE_MNT_NS_FD.initiated()
+            );
+        }
         // Use a pipe to keep the forked child process open
         // till the namespace is read.
 

--- a/zygiskd/src/utils.rs
+++ b/zygiskd/src/utils.rs
@@ -124,7 +124,7 @@ pub fn switch_mount_namespace(pid: i32) -> Result<()> {
 
 // save mount namespaces for all application process
 static CLEAN_MNT_NS_FD: LateInit<i32> = LateInit::new();
-static ROOT_MNT_NS_FD: LateInit<i32> = LateInit::new();
+pub static ROOT_MNT_NS_FD: LateInit<i32> = LateInit::new();
 static MODULE_MNT_NS_FD: LateInit<i32> = LateInit::new();
 
 // Use `man 7 namespaces` to read the Linux manual about namespaces.

--- a/zygiskd/src/utils.rs
+++ b/zygiskd/src/utils.rs
@@ -124,7 +124,7 @@ pub fn switch_mount_namespace(pid: i32) -> Result<()> {
 
 // save mount namespaces for all application process
 static CLEAN_MNT_NS_FD: LateInit<i32> = LateInit::new();
-pub static ROOT_MNT_NS_FD: LateInit<i32> = LateInit::new();
+static ROOT_MNT_NS_FD: LateInit<i32> = LateInit::new();
 static MODULE_MNT_NS_FD: LateInit<i32> = LateInit::new();
 
 // Use `man 7 namespaces` to read the Linux manual about namespaces.

--- a/zygiskd/src/zygiskd.rs
+++ b/zygiskd/src/zygiskd.rs
@@ -94,10 +94,10 @@ pub fn main() -> Result<()> {
         trace!("New daemon action {:?}", action);
         match action {
             DaemonSocketAction::CacheMountNamespace => {
-                let pid = stream.read_u32()?;
-                save_mount_namespace(pid as i32, MountNamespace::Clean)?;
-                save_mount_namespace(pid as i32, MountNamespace::Root)?;
-                save_mount_namespace(pid as i32, MountNamespace::Module)?;
+                let pid = stream.read_u32()? as i32;
+                save_mount_namespace(pid, MountNamespace::Clean)?;
+                save_mount_namespace(pid, MountNamespace::Root)?;
+                save_mount_namespace(pid, MountNamespace::Module)?;
             }
             DaemonSocketAction::PingHeartbeat => {
                 let value = constants::ZYGOTE_INJECTED;


### PR DESCRIPTION
There are two calls of `update_mount_namespace` with parameter `zygiskd::MountNamespace::Clean`.
In some rare case, this causes a racing issue, for example, between the daemon requests of [com.android.systemui] and [webview_zygote].

To fully solve the problem of thread racing on save_mount_namespace, we should cache mount profiles in the main thread of daemon.