### PR TITLE
Fix DenyList function for LineageOS

### DIFF
--- a/loader/src/injector/module.hpp
+++ b/loader/src/injector/module.hpp
@@ -324,6 +324,8 @@ struct HookContext {
     void *start_addr = nullptr;
     size_t block_size = 0;
     bool should_unmap = false;
+    bool zygote_unmounted = false;
+    bool unshare_called = false;
     jint MODIFIER_NATIVE = 0;
     jmethodID member_getModifiers = nullptr;
     std::vector<lsplt::MapInfo> cached_map_infos = {};

--- a/zygiskd/src/utils.rs
+++ b/zygiskd/src/utils.rs
@@ -145,7 +145,7 @@ pub fn save_mount_namespace(pid: i32, namespace_type: MountNamespace) -> Result<
     if !is_initialized {
         if pid == -1 {
             bail!(
-                "mount profiles not fully cached: {}, {}, {}",
+                "Caching not finished [Clean, Root, Module]: [{}, {}, {}]",
                 CLEAN_MNT_NS_FD.initiated(),
                 ROOT_MNT_NS_FD.initiated(),
                 MODULE_MNT_NS_FD.initiated()
@@ -179,9 +179,9 @@ pub fn save_mount_namespace(pid: i32, namespace_type: MountNamespace) -> Result<
             }
             child if child > 0 => {
                 // Parent process
-                trace!("waiting {child} to update mount namespace");
+                trace!("waiting {child} to cache mount namespace");
                 if read_int(reader)? == 0 {
-                    trace!("{child} finished updating mount namespace");
+                    trace!("{child} finished caching mount namespace");
                 }
                 let ns_path = format!("/proc/{}/ns/mnt", child);
                 let ns_file = fs::OpenOptions::new().read(true).open(&ns_path)?;


### PR DESCRIPTION
From user bug reports, we see that all app processes in LineageOS are created using `nativeForkAndSpecialize`. Moreover, the function `unshare` is not called, and we end up cleaning the Zygote process for multiple times. Current commit fixes this problem. Additionally, it improves logging of daemon.