### PR TITLE
Clear ptrace_message on old kernels via seccomp

### DIFF
--- a/loader/src/injector/entry.cpp
+++ b/loader/src/injector/entry.cpp
@@ -17,4 +17,5 @@ void entry(void *addr, size_t size, const char *path) {
 
     LOGI("Start hooking");
     hook_entry(addr, size);
+    send_seccomp_event_if_needed();
 }

--- a/loader/src/injector/seccomp.cpp
+++ b/loader/src/injector/seccomp.cpp
@@ -1,0 +1,110 @@
+#include <fcntl.h>
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstdint>
+#include <fstream>
+#include <string>
+
+#include "logging.hpp"
+#include "zygisk.hpp"
+
+/**
+ * @brief Checks if seccomp filters are already being enforced by the system.
+ *
+ * This prevents our injection from interfering with existing, more robust security
+ * mechanisms. It does this by checking for the "Seccomp_filters:" field in
+ * /proc/self/status.
+ *
+ * @return True if seccomp injection should be skipped, false otherwise.
+ */
+static bool should_skip_seccomp_injection() {
+    // Use std::ifstream for automatic resource management (RAII).
+    std::ifstream status_file("/proc/self/status");
+    if (!status_file.is_open()) {
+        // Fail-safe: if we can't check, we skip the injection.
+        return true;
+    }
+
+    const std::string needle = "Seccomp_filters:";
+    std::string line;
+
+    while (std::getline(status_file, line)) {
+        // C++20's starts_with is safer and more expressive than strncmp.
+        if (line.starts_with(needle)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void send_seccomp_event_if_needed() {
+    if (should_skip_seccomp_injection()) {
+        return;
+    }
+
+    // Use std::array for type-safe, fixed-size arrays.
+    std::array<uint32_t, 4> args{};
+
+    // Read random bytes to create a unique syscall signature.
+    {
+        std::ifstream random_file("/dev/urandom", std::ios::binary);
+        if (!random_file.is_open()) {
+            PLOGE("seccomp: open(/dev/urandom)");
+            return;
+        }
+        random_file.read(reinterpret_cast<char *>(args.data()), args.size() * sizeof(uint32_t));
+        if (!random_file) {
+            PLOGE("seccomp: read(random_file)");
+            return;
+        }
+    }  // random_file is automatically closed here by its destructor.
+
+    // Modify a bit to ensure the signature is highly unlikely to occur naturally.
+    args[0] |= 0x10000;
+
+    const std::array<sock_filter, 12> filter = {{
+        // 1. Check if the syscall is __NR_exit_group. If not, allow it.
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_exit_group, 0, 9),
+
+        // 2. If it is __NR_exit_group, check if all 4 arguments match our random signature.
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[0])),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, args[0], 0, 7),
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[1])),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, args[1], 0, 5),
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[2])),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, args[2], 0, 3),
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, args[3])),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, args[3], 0, 1),
+
+        // 3. If everything matches, trap the syscall, triggering a PTRACE_EVENT_SECCOMP.
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRACE),
+
+        // 4. Default action for any non-matching syscall is to allow it.
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    }};
+
+    sock_fprog prog = {
+        .len = static_cast<unsigned short>(filter.size()),
+        // prctl API requires a non-const pointer.
+        .filter = const_cast<sock_filter *>(filter.data()),
+    };
+
+    if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog)) {
+        PLOGE("seccomp: prctl(PR_SET_SECCOMP)");
+        return;
+    }
+
+    // This syscall triggers the seccomp filter. The tracer will intercept it
+    // and prevent it from actually executing, so Zygote will not exit.
+    syscall(__NR_exit_group, args[0], args[1], args[2], args[3]);
+}

--- a/loader/src/injector/zygisk.hpp
+++ b/loader/src/injector/zygisk.hpp
@@ -8,3 +8,5 @@ void hook_entry(void *start_addr, size_t block_size);
 void hookJniNativeMethods(JNIEnv *env, const char *clz, JNINativeMethod *methods, int numMethods);
 
 void clean_trace(const char *path, size_t load, size_t unload, bool spoof_maps);
+
+void send_seccomp_event_if_needed();

--- a/loader/src/ptracer/utils.hpp
+++ b/loader/src/ptracer/utils.hpp
@@ -38,18 +38,22 @@ struct MapInfo {
 #define REG_SP rsp
 #define REG_IP rip
 #define REG_RET rax
+#define REG_SYSNR orig_rax
 #elif defined(__i386__)
 #define REG_SP esp
 #define REG_IP eip
 #define REG_RET eax
+#define REG_SYSNR orig_eax
 #elif defined(__aarch64__)
 #define REG_SP sp
 #define REG_IP pc
 #define REG_RET regs[0]
+#define REG_SYSNR regs[8]
 #elif defined(__arm__)
 #define REG_SP uregs[13]
 #define REG_IP uregs[15]
 #define REG_RET uregs[0]
+#define REG_SYSNR uregs[7]
 #define user_regs_struct user_regs
 #endif
 


### PR DESCRIPTION
This commit introduces a robust method to reset the `ptrace_message` field on older Linux kernels by leveraging a controlled PTRACE_EVENT_SECCOMP event. This resolves a detection vector used by some applications to identify the presence of Zygisk or other ptrace-based frameworks.

Credits to @nampud, see https://github.com/PerformanC/ReZygisk/pull/191 for more details.

Problem Background:
- When a ptracer (like NeoZygisk) traces Zygote and intercepts fork events, the kernel sets a message in Zygote's `ptrace_message` context field, typically containing the PID of the newly forked application process.
- On Linux kernels prior to v6.1, this `ptrace_message` field is not automatically cleared after the fork event is handled. It remains "sticky" in Zygote's process state.
- **The Core Inheritance Issue**: When Zygote forks to create an application process, the new child process *inherits* this stale, non-zero `ptrace_message` value as part of its initial process state.
- **The Detection Vector**: The application can then discover this inherited "taint". A common method is for the application to fork its own child process, which then ptraces its parent (the application process). A call to `PTRACE_GETEVENTMSG` on the application process will reveal the non-zero, inherited value, thus inferring the presence of a traced Zygote.
- Simple clearing methods like triggering a `PTRACE_SYSCALL` stop are ineffective on these older kernels because they do not clear this sticky, inherited message.

Solution Overview:
This patch implements a highly targeted, "surgical" approach to force a new ptrace event that reliably overwrites the stale `ptrace_message` before the application's code runs. The process is as follows:

1.  **Tracer Preparation**: The ptracer process, which has control over Zygote, sets the `PTRACE_O_TRACESECCOMP` option. This enables it to listen for seccomp events from its tracee.

2.  **Tracee-side Trap**: Code injected into the newly forked Zygote child (our loader) performs these steps: a. **Generate a Unique Signature**: It creates a statistically unique syscall signature using random bytes. b. **Install a Narrow Seccomp Filter**: It installs a BPF filter that ignores all syscalls *except* for `__NR_exit_group` when called with the exact unique signature. This specific match returns `SECCOMP_RET_TRACE`, while all other syscalls are allowed. c. **Trigger the Trap**: It immediately calls `syscall(__NR_exit_group, ...)` using the unique signature, intentionally triggering the trap.

3.  **Tracer-side Interception and Defusal**: a. The `syscall` triggers `SECCOMP_RET_TRACE`, causing the kernel to pause the process and notify the ptracer with a `PTRACE_EVENT_SECCOMP`. **This new event successfully overwrites and clears `ptrace_message`.** b. The ptracer catches this event and calls `tracee_skip_syscall()`. c. This crucial function prevents the `exit_group` syscall from ever executing by modifying the process's registers (`REG_SYSNR = -1`), thus ensuring the process does not terminate. d. The ptracer then resumes the process, which continues safely.

Why this solution is robust:
- **Compatibility**: Works on all kernels supporting `seccomp-bpf` (Linux 3.5+, i.e., Android 5.0+), covering the affected device range.
- **Safety**: The filter is extremely narrow and short-lived, posing no risk to the Android security sandbox.
- **No Side Effects**: The dangerous `exit_group` syscall is neutralized before execution, guaranteeing process stability.
- **Reliability**: The process is self-contained and deterministic, providing a more reliable fix than methods like detach/reattach.