### PR TITLE
Update Kernel detection with variants

### DIFF
--- a/zygiskd/src/root_impl/kernelsu.rs
+++ b/zygiskd/src/root_impl/kernelsu.rs
@@ -1,15 +1,29 @@
 use crate::constants::{MAX_KSU_VERSION, MIN_KSU_VERSION};
+use crate::utils::LateInit;
+use std::ffi::c_char;
+use std::path::Path;
 
 const KERNEL_SU_OPTION: u32 = 0xdeadbeefu32;
 
 const CMD_GET_VERSION: usize = 2;
 const CMD_UID_GRANTED_ROOT: usize = 12;
 const CMD_UID_SHOULD_UMOUNT: usize = 13;
+const CMD_GET_MANAGER_UID: usize = 16;
+const CMD_HOOK_MODE: usize = 0xC0DEAD1A;
+
+// An enum is needed to represent the different KernelSU variants.
+#[derive(Clone, Copy)]
+pub enum KernelSuVariant {
+    Official,
+    Next,
+}
+
+static VARIANT: LateInit<KernelSuVariant> = LateInit::new();
+static SUPPORTS_MANAGER_UID_RETRIEVAL: LateInit<bool> = LateInit::new();
 
 pub enum Version {
     Supported,
     TooOld,
-    Abnormal,
 }
 
 pub fn get_kernel_su() -> Option<Version> {
@@ -23,12 +37,54 @@ pub fn get_kernel_su() -> Option<Version> {
             0,
         )
     };
+
     const MAX_OLD_VERSION: i32 = MIN_KSU_VERSION - 1;
     match version {
-        0 => None,
-        MIN_KSU_VERSION..=MAX_KSU_VERSION => Some(Version::Supported),
+        MIN_KSU_VERSION..=MAX_KSU_VERSION => {
+            // Check for the `ksud` daemon's existence. If it's not present,
+            // KernelSU is not considered active, so we return None.
+            if !Path::new("/data/adb/ksud").exists() {
+                return None;
+            }
+
+            // This block runs once to detect and cache kernel capabilities.
+            if !VARIANT.initiated() {
+                // Detect kernel variant (Official vs. Next).
+                let mut mode: [c_char; 16] = [0; 16];
+                unsafe {
+                    libc::prctl(
+                        KERNEL_SU_OPTION as i32,
+                        CMD_HOOK_MODE,
+                        mode.as_mut_ptr() as usize,
+                        0,
+                        0,
+                    );
+                }
+                VARIANT.init(if mode[0] != 0 {
+                    KernelSuVariant::Next
+                } else {
+                    KernelSuVariant::Official
+                });
+
+                // Check if the kernel supports direct manager UID retrieval.
+                let mut mgr_uid_reply_ok: i32 = 0;
+                unsafe {
+                    libc::prctl(
+                        KERNEL_SU_OPTION as i32,
+                        CMD_GET_MANAGER_UID,
+                        0,
+                        0,
+                        &mut mgr_uid_reply_ok as *mut _ as usize,
+                    );
+                }
+                SUPPORTS_MANAGER_UID_RETRIEVAL.init(mgr_uid_reply_ok as u32 == KERNEL_SU_OPTION);
+            }
+
+            Some(Version::Supported)
+        }
         1..=MAX_OLD_VERSION => Some(Version::TooOld),
-        _ => Some(Version::Abnormal),
+        // A version of 0 or any other value means KernelSU is not present or abnormal.
+        _ => None,
     }
 }
 
@@ -44,8 +100,9 @@ pub fn uid_granted_root(uid: i32) -> bool {
             &mut result as *mut u32,
         )
     };
+    // The prctl call is valid only if `result` matches `KERNEL_SU_OPTION`.
     if result != KERNEL_SU_OPTION {
-        log::warn!("uid_granted_root failed");
+        return false;
     }
     granted
 }
@@ -62,15 +119,42 @@ pub fn uid_should_umount(uid: i32) -> bool {
             &mut result as *mut u32,
         )
     };
+    // The prctl call is valid only if `result` matches `KERNEL_SU_OPTION`.
     if result != KERNEL_SU_OPTION {
-        log::warn!("uid_granted_root failed");
+        return false;
     }
     umount
 }
 
-// TODO: signature
 pub fn uid_is_manager(uid: i32) -> bool {
-    if let Ok(s) = rustix::fs::stat("/data/user_de/0/me.weishu.kernelsu") {
+    // Ensure the static variables are initialized before use.
+    if !VARIANT.initiated() {
+        get_kernel_su();
+    }
+
+    // If supported, getting the manager UID from the kernel is most reliable.
+    if *SUPPORTS_MANAGER_UID_RETRIEVAL {
+        let mut manager_uid: u32 = 0;
+        let mut reply_ok: i32 = 0;
+        unsafe {
+            libc::prctl(
+                KERNEL_SU_OPTION as i32,
+                CMD_GET_MANAGER_UID,
+                &mut manager_uid as *mut u32,
+                0,
+                &mut reply_ok as *mut i32,
+            )
+        };
+        return uid as u32 == manager_uid;
+    }
+
+    // Fallback to checking the path based on the detected variant.
+    let manager_path = match *VARIANT {
+        KernelSuVariant::Official => "/data/user_de/0/me.weishu.kernelsu",
+        KernelSuVariant::Next => "/data/user_de/0/com.rifsxd.ksunext",
+    };
+
+    if let Ok(s) = rustix::fs::stat(manager_path) {
         return s.st_uid == uid as u32;
     }
     false

--- a/zygiskd/src/root_impl/mod.rs
+++ b/zygiskd/src/root_impl/mod.rs
@@ -6,7 +6,6 @@ mod magisk;
 pub enum RootImpl {
     None,
     TooOld,
-    Abnormal,
     Multiple,
     APatch,
     KernelSU,
@@ -33,7 +32,6 @@ pub fn setup() {
         (None, Some(ksu_version), None) => match ksu_version {
             kernelsu::Version::Supported => RootImpl::KernelSU,
             kernelsu::Version::TooOld => RootImpl::TooOld,
-            kernelsu::Version::Abnormal => RootImpl::Abnormal,
         },
         (None, None, Some(magisk_version)) => match magisk_version {
             magisk::Version::Supported => RootImpl::Magisk,


### PR DESCRIPTION
We enhance the KernelSU implementation by adding detection for variants (Official vs. Next) and confirming that the `ksud` daemon exists for an active installation.

The `uid_is_manager` check is now more reliable by first attempting to retrieve the manager UID directly from the kernel before falling back to checking data paths.

Close #28 and #20 as completed.