### PR TITLE
Correct process flags of isolated services

### DIFF
--- a/loader/src/include/misc.hpp
+++ b/loader/src/include/misc.hpp
@@ -7,6 +7,11 @@
 #include <string>
 #include <string_view>
 
+// Reference:
+// https://cs.android.com/android/platform/superproject/main/+/main:system/core/libcutils/include/private/android_filesystem_config.h
+#define AID_ISOLATED_START 90000 /* start of uids for fully isolated sandboxed processes */
+#define AID_ISOLATED_END 99999   /* end of uids for fully isolated sandboxed processes */
+
 #define DISALLOW_COPY_AND_MOVE(clazz)                                                              \
     clazz(const clazz &) = delete;                                                                 \
     clazz(clazz &&) = delete;


### PR DESCRIPTION
We retrieve the uid of isolated services via their application directories, so that the DenyList setting is applied to them correctly.

This detection method and its solution are found by @ThePedroo, see https://github.com/PerformanC/ReZygisk/commit/48238521dfbea98ed9c63cfa5a9e2fbb50f52c74.