### PR TITLE
Avoid modifying zygote mount namespace

### DIFF
--- a/loader/src/injector/hook.cpp
+++ b/loader/src/injector/hook.cpp
@@ -112,7 +112,7 @@ DCL_HOOK_FUNC(static int, unshare, int flags) {
             ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Root);
         } else if (!(g_ctx->flags & DO_REVERT_UNMOUNT)) {
             ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Module);
-        } else if (g_hook->zygote_mns != zygiskd::MountNamespace::Clean) {
+        } else {
             ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Clean);
         }
         old_unshare(CLONE_NEWNS);

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -263,60 +263,20 @@ void ZygiskContext::fork_pre() {
     sigmask(SIG_BLOCK, SIGCHLD);
     pid = old_fork();
 
-    if ((flags & SERVER_FORK_AND_SPECIALIZE) && !is_child()) return;
+    if (!is_child()) return;
 
-    if (g_hook->zygote_mns != zygiskd::MountNamespace::Clean) {
-        if (!is_child()) {
-            // If zygote mns is not clean, then we have updated it before,
-            // and can thus skip the following check of accessibility
-            LOGV("zygote mns is not clean");
-            return;
-        } else if (flags & APP_FORK_AND_SPECIALIZE) {
-            // We must set clean mns for the child process before checking accessibility
-            update_mount_namespace(zygiskd::MountNamespace::Clean);
-        }
-    }
-
-    // Record all open fds, and check their accessibility under current mns
+    // Record all open fds
     auto dir = xopen_dir("/proc/self/fd");
-    char path[PATH_MAX];
     for (dirent *entry; (entry = readdir(dir.get()));) {
         int fd = parse_int(entry->d_name);
         if (fd < 0 || static_cast<size_t>(fd) >= allowed_fds.size()) {
             close(fd);
             continue;
         }
-
-        std::string fd_path = "/proc/self/fd/" + std::to_string(fd);
-        ssize_t len = readlink(fd_path.c_str(), path, sizeof(path) - 1);
-        path[len == -1 ? 0 : len] = '\0';
-        std::string path_found_from_fd = std::string(path);
-        if (path_found_from_fd.empty() || path_found_from_fd.contains(":[") ||
-            path_found_from_fd.starts_with("/dev/")) {
-            allowed_fds[fd] = true;
-        } else {
-            struct stat info_from_path;
-            if (stat(path, &info_from_path) == -1) {
-                allowed_fds[fd] = false;
-                if (!is_child()) {
-                    LOGV("module file %s [fd=%d] is loaded by zygote", path, fd);
-                    // Avoid ReopenOrDetach this fd during zygote::forkApp
-                    g_hook->zygote_mns = zygiskd::MountNamespace::Module;
-                } else {
-                    // Avoid ReopenOrDetach this fd during child's specialization
-                    close(fd);
-                }
-            } else {
-                allowed_fds[fd] = true;
-            }
-        }
+        allowed_fds[fd] = true;
     }
     // The dirfd will be closed once out of scope
     allowed_fds[dirfd(dir.get())] = false;
-
-    if (!is_child() && (flags & APP_FORK_AND_SPECIALIZE)) {
-        update_mount_namespace(g_hook->zygote_mns);
-    }
 }
 
 void ZygiskContext::fork_post() {
@@ -454,15 +414,6 @@ void ZygiskContext::nativeForkAndSpecialize_pre() {
     process = env->GetStringUTFChars(args.app->nice_name, nullptr);
     LOGV("pre forkAndSpecialize [%s]\n", process);
     flags |= APP_FORK_AND_SPECIALIZE;
-
-    if (g_hook->zygote_mns == zygiskd::MountNamespace::Root) {
-        zygiskd::CacheMountNamespace(getpid());
-
-        // Unmount the root mount namespace of Zygote
-        g_hook->zygote_mns = zygiskd::MountNamespace::Clean;
-        update_mount_namespace(g_hook->zygote_mns);
-        LOGV("mount points of zygote cleaned");
-    }
 
     fork_pre();
     if (is_child()) {

--- a/loader/src/injector/module.hpp
+++ b/loader/src/injector/module.hpp
@@ -324,7 +324,6 @@ struct HookContext {
     bool should_spoof_maps = false;
     bool should_unmap = false;
     bool skip_hooking_unloader = false;
-    zygiskd::MountNamespace zygote_mns = zygiskd::MountNamespace::Root;
     jint MODIFIER_NATIVE = 0;
     jmethodID member_getModifiers = nullptr;
     std::vector<lsplt::MapInfo> cached_map_infos = {};


### PR DESCRIPTION
In my first conception of the `DenyList` implementation via mount namespace, I had the motivation of providing a clean namespace in the most efficient way. Hence, I was eager to clean the zygote process first and then remount necessary mounting points according to users' configurations.

However, modifying the zygote mount namespace is not totally invisible to application processes. They can still inspect the `mnt_id` of system directories, such as `/apex/com.android.art/`, via [proc_pid_fdinfo](https://man7.org/linux/man-pages/man5/proc_pid_fdinfo.5.html). If we clean the zygote mount namespace via `setns`, then we undoubtedly increase the numeric values of these mount IDs, rendering them significantly larger than 1000. Indeed, `setns` re-assigns the mount IDs for all mounting points, instead of reusing any of them. Hence, the original design choice has introduced a detection point based on certain heuristic threshold of these numerical values.

Given this design flaw, we now avoid modifying zygote mount namespace, and call `setns`, i.e, `update_mount_namespace`, only after `unshare`.