### PR TITLE
Evade atexit handler detection

### DIFF
--- a/loader/src/injector/entry.cpp
+++ b/loader/src/injector/entry.cpp
@@ -1,3 +1,5 @@
+#include <dlfcn.h>
+
 #include "daemon.hpp"
 #include "logging.hpp"
 #include "zygisk.hpp"
@@ -5,7 +7,7 @@
 using namespace std;
 
 extern "C" [[gnu::visibility("default")]]
-void entry(void *addr, size_t size, const char *path) {
+void entry(void* addr, size_t size, const char* path) {
     LOGI("Zygisk library injected, version %s", ZKSU_VERSION);
 
     zygiskd::Init(path);
@@ -18,4 +20,39 @@ void entry(void *addr, size_t size, const char *path) {
     LOGI("Start hooking");
     hook_entry(addr, size);
     send_seccomp_event_if_needed();
+}
+
+/**
+ * @brief Intercepts calls to __cxa_atexit to prevent registration of exit handlers.
+ *
+ * This function serves as a local replacement for the __cxa_atexit provided by libc.
+ * By providing our own version, the dynamic linker resolves any calls from within our
+ * injector library (and its static dependencies) to this function instead of the real one.
+ *
+ * @param func The function pointer (destructor) to be registered.
+ * @param arg  A pointer to the argument for the function (the 'this' pointer for an object).
+ * @param dso  A handle to the shared object that is registering the handler.
+ * @return int Always returns 0 to indicate success, tricking the caller into thinking
+ *             the handler was registered while we have actually blocked it.
+ */
+extern "C" int __cxa_atexit(void (*func)(void*), void* arg, void* dso) {
+    // Dl_info will be filled with information about the library
+    // containing the function pointer 'func'.
+    Dl_info info;
+
+    // Use dladdr() to resolve the function pointer to a library and symbol.
+    if (dladdr(reinterpret_cast<const void*>(func), &info)) {
+        // Successfully resolved the address.
+        const char* library_path = info.dli_fname ? info.dli_fname : "<unknown library>";
+        const char* symbol_name = info.dli_sname ? info.dli_sname : "<unknown symbol>";
+
+        LOGD("atexit registration BLOCKED [func, lib, sym, obj, dso]: [%p, %s, %s, %p, %p]", func,
+             library_path, symbol_name, arg, dso);
+
+    } else {
+        // dladdr() failed. We can still log the raw pointer.
+        LOGD("atexit registration BLOCKED for function at %p without library information).", func);
+    }
+
+    return 0;
 }


### PR DESCRIPTION
When a global or static C++ object is created, the runtime registers its destructor to be called at exit. This is done via the `__cxa_atexit` function, which populates an internal handler list within `libc`. In Android's Bionic `libc`, this list is a global static object [AtexitArray g_array](https://cs.android.com/android/platform/superproject/main/+/main:bionic/libc/bionic/atexit.cpp).

Security solutions can locate this `g_array` object in memory and inspect its entries. By resolving the function pointers within the array, they can identify handlers that originate from our injected library, leaving a clear fingerprint of our presence—even after our library has been unmapped.

We thus introduce a local `__cxa_atexit` implementation within our library. Due to symbol interposition, this function intercepts all registration attempts from our code and its dependencies.

The function blocks the registration, ensuring no entries from our module are ever added to `libc`'s `g_array`. It also logs detailed diagnostics about the intercepted calls, helping developers identify the source of global objects. This completely neutralizes the detection vector.

This detection point is disclosed in [this commit](https://github.com/nampud/ReZygisk/commit/97797acae837141d7ea09c6d3448956812072d9d) of @nampud.