### PR TITLE
Refactor mount namespace profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Here is how NeoZygisk manages visibility for different application states:
 | Application State | Mount Namespace Visibility | Description & Use Case |
 | :--- | :--- | :--- |
 | **Granted Root Privileges** | Root Solution Mounts + Module Mounts | For trusted applications that require full root access to function correctly (e.g., advanced file managers). |
-| **Standard App** <br/>*(Not on DenyList)* | **(APatch/KSU Only)** <br/> Module Mounts Only | Ideal for applying modules (like custom fonts or themes) to target apps without exposing the root environment. <br/> **Note:** This is not implemented for Magisk, as it requires root mounts to be visible for handling permission requests. |
 | **On DenyList** | Clean, Unmodified Mount Namespace | Provides a pristine environment for applications that perform root detection. The app's root privileges are revoked, and all traces of root and module mounts are hidden. |
 
 ## Configuration

--- a/loader/src/include/daemon.hpp
+++ b/loader/src/include/daemon.hpp
@@ -67,7 +67,7 @@ enum class SocketAction {
     SystemServerStarted,
 };
 
-enum class MountNamespace { Clean, Root, Module };
+enum class MountNamespace { Clean, Root };
 
 void Init(const char* path);
 

--- a/loader/src/injector/hook.cpp
+++ b/loader/src/injector/hook.cpp
@@ -110,12 +110,10 @@ DCL_HOOK_FUNC(static int, unshare, int flags) {
         !(g_ctx->flags & SERVER_FORK_AND_SPECIALIZE) && !(g_ctx->info_flags & IS_FIRST_PROCESS)) {
         if (g_ctx->info_flags & (PROCESS_IS_MANAGER | PROCESS_GRANTED_ROOT)) {
             ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Root);
-        } else if (!(g_ctx->flags & DO_REVERT_UNMOUNT)) {
-            ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Module);
-        } else {
+        } else if (g_ctx->flags & DO_REVERT_UNMOUNT) {
             ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Clean);
+            old_unshare(CLONE_NEWNS); // remove gaps in mounting IDs
         }
-        old_unshare(CLONE_NEWNS);
     }
     // Restore errno back to 0
     errno = 0;

--- a/loader/src/injector/hook.cpp
+++ b/loader/src/injector/hook.cpp
@@ -112,8 +112,8 @@ DCL_HOOK_FUNC(static int, unshare, int flags) {
             ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Root);
         } else if (g_ctx->flags & DO_REVERT_UNMOUNT) {
             ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Clean);
-            old_unshare(CLONE_NEWNS); // remove gaps in mounting IDs
         }
+        old_unshare(CLONE_NEWNS);  // remove gaps in mounting IDs
     }
     // Restore errno back to 0
     errno = 0;

--- a/zygiskd/src/constants.rs
+++ b/zygiskd/src/constants.rs
@@ -41,7 +41,6 @@ pub enum DaemonSocketAction {
 pub enum MountNamespace {
     Clean,
     Root,
-    Module,
 }
 
 // Zygisk process flags

--- a/zygiskd/src/zygiskd.rs
+++ b/zygiskd/src/zygiskd.rs
@@ -97,7 +97,6 @@ pub fn main() -> Result<()> {
                 let pid = stream.read_u32()? as i32;
                 save_mount_namespace(pid, MountNamespace::Clean)?;
                 save_mount_namespace(pid, MountNamespace::Root)?;
-                save_mount_namespace(pid, MountNamespace::Module)?;
             }
             DaemonSocketAction::PingHeartbeat => {
                 let value = constants::ZYGOTE_INJECTED;


### PR DESCRIPTION
1. Remove the `Module` profile of mount namespace, since there is no root mounts (such as `su` binary) to unmount for KernelSU / APatch;
2. Unmount KernelSU modules files that are identified via a loop device.