### PR TITLE
Implement direct unmounting of traces in zygote

### DIFF
--- a/loader/src/common/daemon.cpp
+++ b/loader/src/common/daemon.cpp
@@ -9,7 +9,7 @@
 
 namespace zygiskd {
 static std::string TMP_PATH;
-static bool mount_namspace_cached = false;
+static bool caching_action_called = false;
 
 void Init(const char *path) { TMP_PATH = path; }
 
@@ -60,8 +60,8 @@ uint32_t GetProcessFlags(uid_t uid) {
 }
 
 void CacheMountNamespace(pid_t pid, bool forced) {
-    if (mount_namspace_cached && !forced) return;
-    mount_namspace_cached = true;
+    if (caching_action_called && !forced) return;
+    caching_action_called = true;
     UniqueFd fd = Connect(1);
     if (fd == -1) {
         PLOGE("CacheMountNamespace");

--- a/loader/src/injector/hook.cpp
+++ b/loader/src/injector/hook.cpp
@@ -109,7 +109,8 @@ DCL_HOOK_FUNC(static int, unshare, int flags) {
         !(g_ctx->flags & SERVER_FORK_AND_SPECIALIZE) && !(g_ctx->info_flags & IS_FIRST_PROCESS)) {
         if (g_ctx->info_flags & (PROCESS_IS_MANAGER | PROCESS_GRANTED_ROOT)) {
             ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Root);
-        } else if (g_ctx->flags & DO_REVERT_UNMOUNT) {
+        } else if (!(g_hook->zygote_unmounted && g_hook->zygote_traces.size() == 0) &&
+                   (g_ctx->flags & DO_REVERT_UNMOUNT)) {
             ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Clean);
         }
     }

--- a/loader/src/injector/hook.cpp
+++ b/loader/src/injector/hook.cpp
@@ -107,11 +107,17 @@ DCL_HOOK_FUNC(static int, unshare, int flags) {
     if (g_ctx && (flags & CLONE_NEWNS) &&
         // Skip system server and the first app process since we don't need to hide traces for them
         !(g_ctx->flags & SERVER_FORK_AND_SPECIALIZE) && !(g_ctx->info_flags & IS_FIRST_PROCESS)) {
-        if (g_ctx->info_flags & (PROCESS_IS_MANAGER | PROCESS_GRANTED_ROOT)) {
-            ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Root);
-        } else if (!(g_hook->zygote_unmounted && g_hook->zygote_traces.size() == 0) &&
-                   (g_ctx->flags & DO_REVERT_UNMOUNT)) {
-            ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Clean);
+        bool is_zygote_clean = g_hook->zygote_unmounted && g_hook->zygote_traces.size() == 0;
+        if (is_zygote_clean) {
+            if (!(g_ctx->flags & DO_REVERT_UNMOUNT)) {
+                ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Root);
+            }
+        } else {
+            if (g_ctx->info_flags & (PROCESS_IS_MANAGER | PROCESS_GRANTED_ROOT)) {
+                ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Root);
+            } else if (g_ctx->flags & DO_REVERT_UNMOUNT) {
+                ZygiskContext::update_mount_namespace(zygiskd::MountNamespace::Clean);
+            }
         }
     }
 

--- a/loader/src/injector/module.hpp
+++ b/loader/src/injector/module.hpp
@@ -10,6 +10,7 @@
 #include "api.hpp"
 #include "daemon.hpp"
 #include "lsplt.hpp"
+#include "zygisk.hpp"
 
 struct ZygiskContext;
 struct HookContext;
@@ -324,10 +325,12 @@ struct HookContext {
     bool should_spoof_maps = false;
     bool should_unmap = false;
     bool skip_hooking_unloader = false;
+    bool zygote_unmounted = false;
     jint MODIFIER_NATIVE = 0;
     jmethodID member_getModifiers = nullptr;
     std::vector<lsplt::MapInfo> cached_map_infos = {};
     std::vector<std::tuple<dev_t, ino_t, const char *, void **>> plt_backup;
+    std::vector<mount_info> zygote_traces;
 
     HookContext(void *start_addr, size_t block_size);
 

--- a/loader/src/injector/unmount.cpp
+++ b/loader/src/injector/unmount.cpp
@@ -87,6 +87,7 @@ std::vector<mount_info> parse_mount_info(const char* pid) {
             info.fs_options = remaining_fs.substr(1);  // Trim leading space
         }
 
+        info.raw_info = line;
         result.push_back(std::move(info));
     }
     return result;

--- a/loader/src/injector/unmount.cpp
+++ b/loader/src/injector/unmount.cpp
@@ -1,0 +1,156 @@
+#include <sys/sysmacros.h>  // For makedev
+#include <sys/types.h>
+
+#include <algorithm>  // For std::sort
+#include <cerrno>     // For errno
+#include <cstdio>     // For sscanf
+#include <cstring>    // For strerror
+#include <fstream>    // For std::ifstream
+#include <sstream>    // For std::stringstream
+#include <stdexcept>  // For std::stoul
+#include <string>
+#include <vector>
+
+#include "logging.hpp"
+#include "module.hpp"
+#include "zygisk.hpp"
+
+static bool starts_with(const std::string& str, const std::string& prefix) {
+    return str.rfind(prefix, 0) == 0;
+}
+
+std::vector<mount_info> parse_mount_info(const char* pid) {
+    std::string path = "/proc/";
+    path += pid;
+    path += "/mountinfo";
+
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        LOGE("failed to open %s: %s", path.c_str(), strerror(errno));
+        return {};
+    }
+
+    std::vector<mount_info> result;
+    std::string line;
+    while (std::getline(file, line)) {
+        // The " - " separator is the only guaranteed, unambiguous delimiter on a valid line.
+        size_t separator_pos = line.find(" - ");
+        if (separator_pos == std::string::npos) {
+            LOGE("malformed line (no ' - ' separator): %s", line.c_str());
+            continue;
+        }
+
+        // Split the line into the part before the separator and the part after.
+        std::string part1_str = line.substr(0, separator_pos);
+        std::string part2_str = line.substr(separator_pos + 3);
+
+        std::stringstream p1_ss(part1_str);
+        mount_info info = {};
+        std::string device_str;
+
+        // 1. Parse the fixed-format fields from the first part of the line.
+        p1_ss >> info.id >> info.parent >> device_str >> info.root >> info.target;
+        if (p1_ss.fail()) {
+            LOGE("malformed line (failed parsing first section): %s", line.c_str());
+            continue;
+        }
+
+        // 2. Parse the "major:minor" string.
+        // sscanf is ideal for this fixed format and returns the number of items matched.
+        unsigned int maj = 0, min = 0;
+        if (sscanf(device_str.c_str(), "%u:%u", &maj, &min) != 2) {
+            LOGE("malformed line (invalid device format): %s", line.c_str());
+            continue;
+        }
+        info.device = makedev(maj, min);
+
+        // 3. The remainder of the first part is the vfs_options.
+        // We use getline to consume everything left in the stream.
+        std::string remaining_vfs;
+        std::getline(p1_ss, remaining_vfs);
+        if (!remaining_vfs.empty() && remaining_vfs.front() == ' ') {
+            info.vfs_options = remaining_vfs.substr(1);  // Trim leading space
+        }
+
+        // 4. Parse the second part of the line.
+        std::stringstream p2_ss(part2_str);
+        p2_ss >> info.type >> info.source;
+        if (p2_ss.fail()) {
+            LOGE("malformed line (failed parsing type/source): %s", line.c_str());
+            continue;
+        }
+
+        // 5. The remainder of the second part is the fs_options.
+        std::string remaining_fs;
+        std::getline(p2_ss, remaining_fs);
+        if (!remaining_fs.empty() && remaining_fs.front() == ' ') {
+            info.fs_options = remaining_fs.substr(1);  // Trim leading space
+        }
+
+        result.push_back(std::move(info));
+    }
+    return result;
+}
+
+std::vector<mount_info> check_zygote_traces(uint32_t info_flags) {
+    std::vector<mount_info> traces;
+
+    auto mount_infos = parse_mount_info("self");
+    if (mount_infos.empty()) {
+        // This is not an error if the parsing simply found no mounts.
+        // It could be an error if parsing failed, which is logged in the function itself.
+        LOGD("mount info is empty or could not be parsed.");
+        return traces;
+    }
+
+    const char* mount_source_name = nullptr;
+    bool is_kernelsu = false;
+
+    if (info_flags & PROCESS_ROOT_IS_APATCH) {
+        mount_source_name = "APatch";
+    } else if (info_flags & PROCESS_ROOT_IS_KSU) {
+        mount_source_name = "KSU";
+        is_kernelsu = true;
+    } else if (info_flags & PROCESS_ROOT_IS_MAGISK) {
+        mount_source_name = "magisk";
+    } else {
+        LOGE("could not determine root implementation, aborting unmount.");
+        return traces;
+    }
+
+    std::string kernel_su_module_source;
+    if (is_kernelsu) {
+        for (const auto& info : mount_infos) {
+            if (info.target == "/data/adb/modules" && starts_with(info.source, "/dev/block/loop")) {
+                kernel_su_module_source = info.source;
+                LOGD("detected KernelSU loop device module source: %s",
+                     kernel_su_module_source.c_str());
+                break;
+            }
+        }
+    }
+
+    for (const auto& info : mount_infos) {
+        const bool should_unmount =
+            starts_with(info.root, "/adb/modules") ||
+            starts_with(info.target, "/data/adb/modules") || (info.source == mount_source_name) ||
+            (!kernel_su_module_source.empty() && info.source == kernel_su_module_source);
+
+        if (should_unmount) {
+            traces.push_back(info);
+        }
+    }
+
+    if (traces.empty()) {
+        LOGD("No relevant mount points found to unmount.");
+        return traces;
+    }
+
+    // Sort the collected traces by mount ID in descending order for safe unmounting
+    std::sort(traces.begin(), traces.end(),
+              [](const mount_info& a, const mount_info& b) { return a.id > b.id; });
+
+    LOGD("found %zu mounting traces in zygote.", traces.size());
+
+    return traces;
+}

--- a/loader/src/injector/zygisk.hpp
+++ b/loader/src/injector/zygisk.hpp
@@ -15,6 +15,7 @@ struct mount_info {
     std::string type;
     std::string source;
     std::string fs_options;
+    std::string raw_info;
 };
 
 void hook_entry(void *start_addr, size_t block_size);

--- a/loader/src/injector/zygisk.hpp
+++ b/loader/src/injector/zygisk.hpp
@@ -3,6 +3,20 @@
 #include <jni.h>
 #include <sys/types.h>
 
+#include <string>
+
+struct mount_info {
+    unsigned int id;
+    unsigned int parent;
+    dev_t device;
+    std::string root;
+    std::string target;
+    std::string vfs_options;
+    std::string type;
+    std::string source;
+    std::string fs_options;
+};
+
 void hook_entry(void *start_addr, size_t block_size);
 
 void hookJniNativeMethods(JNIEnv *env, const char *clz, JNINativeMethod *methods, int numMethods);
@@ -15,3 +29,5 @@ void spoof_virtual_maps(const char *path, bool clear_write_permission);
 void spoof_zygote_fossil(char *search_from, char *search_to, const char *anchor);
 
 void send_seccomp_event_if_needed();
+
+std::vector<mount_info> check_zygote_traces(uint32_t info_flags);


### PR DESCRIPTION
This commit introduces an alternative, more direct approach to prevent potential mount trace leaks from the zygote process to its children.

Instead of relying solely on `setns` to switch forked processes to a clean namespace profile, this new mechanism actively finds and unmounts traces within the zygote itself. This is an experimental approach to test if a more aggressive, earlier cleanup can bypass certain root detection methods.

The implementation includes:
- A new `unmount.cpp` file that identifies root traces as the zygisk daemon.

- The unmount process is triggered once, just before an app process specializes in `nativeForkAndSpecialize_pre`.

- It attempts to unmount all identified traces. The `erase-remove` idiom is used to efficiently update the list of traces, retaining only those that failed to unmount.

- The global `HookContext` is updated to track the unmount state (`zygote_unmounted`) and the list of remaining traces.

The existing `setns`-based cleanup in the `unshare` hook is now made conditional. It will be skipped if this new direct unmount procedure has already run and successfully removed all traces.