### PR TITLE
Force recompaction of g_array to remove atexit fingerprint

### DIFF
--- a/loader/src/include/atexit.hpp
+++ b/loader/src/include/atexit.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <pthread.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/auxv.h>
+#include <sys/cdefs.h>
+#include <sys/mman.h>
+#include <sys/param.h>
+#include <sys/prctl.h>
+#include <sys/user.h>
+
+#include <memory>
+#include <sstream>
+
+namespace Atexit {
+
+inline size_t page_size() {
+#if defined(PAGE_SIZE)
+    return PAGE_SIZE;
+#else
+    static const size_t page_size = getauxval(AT_PAGESZ);
+    return page_size;
+#endif
+}
+
+// The maximum page size supported on any Android device. As
+// of API level 35, this is limited by ART.
+constexpr size_t max_android_page_size() {
+#if defined(PAGE_SIZE)
+    return PAGE_SIZE;
+#else
+    return 16384;
+#endif
+}
+
+// Returns the address of the page containing address 'x'.
+inline uintptr_t page_start(uintptr_t x) { return x & ~(page_size() - 1); }
+
+// Returns the offset of address 'x' in its page.
+inline uintptr_t page_offset(uintptr_t x) { return x & (page_size() - 1); }
+
+// Returns the address of the next page after address 'x', unless 'x' is
+// itself at the start of a page.
+inline uintptr_t page_end(uintptr_t x) { return page_start(x + page_size() - 1); }
+
+struct AtexitEntry {
+    void (*fn)(void*);  // the __cxa_atexit callback
+    void* arg;          // argument for `fn` callback
+    void* dso;          // shared module handle
+};
+
+class AtexitArray {
+public:
+    AtexitArray(AtexitEntry* existing_array, size_t current_size, size_t current_capacity,
+                size_t initial_extracted_count, uint64_t initial_total_appends)
+        : array_(existing_array),
+          size_(current_size),
+          extracted_count_(initial_extracted_count),
+          capacity_(current_capacity),
+          total_appends_(initial_total_appends) {}
+
+    std::string format_state_string() const {
+        std::stringstream ss;
+
+        // Use the << operator to stream text and variables into the stringstream.
+        // The '\n' and '\t' characters provide the desired logcat formatting.
+        ss << "\n--- Live AtexitArray Snapshot State ---\n";
+        ss << "\t(this pointer):  " << static_cast<const void*>(this) << "\n";
+        ss << "\tarray_:          " << static_cast<const void*>(array_) << "\n";
+
+        // For numeric values, show both decimal and hexadecimal for easier debugging.
+        ss << "\tsize_:           " << size_ << " (0x" << std::hex << size_ << std::dec << ")\n";
+        ss << "\textracted_count_: " << extracted_count_ << " (0x" << std::hex << extracted_count_
+           << std::dec << ")\n";
+        ss << "\tcapacity_:       " << capacity_ << " (0x" << std::hex << capacity_ << std::dec
+           << ")\n";
+        ss << "\ttotal_appends_:  " << total_appends_ << " (0x" << std::hex << total_appends_
+           << std::dec << ")\n";
+
+        ss << "---------------------------------------";
+
+        // The .str() method returns the complete, concatenated string.
+        return ss.str();
+    }
+
+    size_t size() const { return size_; }
+    uint64_t total_appends() const { return total_appends_; }
+    const AtexitEntry& operator[](size_t idx) const { return array_[idx]; }
+
+    void recompact();
+
+private:
+    AtexitEntry* array_;
+    size_t size_;
+    size_t extracted_count_;
+    size_t capacity_;
+
+    // An entry can be appended by a __cxa_finalize callback. Track the number of appends so we
+    // restart concurrent __cxa_finalize passes.
+    uint64_t total_appends_;
+
+    static size_t page_start_of_index(size_t idx) { return page_start(idx * sizeof(AtexitEntry)); }
+    static size_t page_end_of_index(size_t idx) { return page_end(idx * sizeof(AtexitEntry)); }
+
+    // Recompact the array if it will save at least one page of memory at the end.
+    bool needs_recompaction() const {
+        return page_end_of_index(size_ - extracted_count_) < page_end_of_index(size_);
+    }
+
+    void set_writable(bool writable, size_t start_idx, size_t num_entries);
+};
+
+AtexitArray* findAtexitArray();
+
+}  // namespace Atexit

--- a/loader/src/injector/atexit.cpp
+++ b/loader/src/injector/atexit.cpp
@@ -1,0 +1,84 @@
+#include "atexit.hpp"
+
+#include "elf_util.hpp"
+#include "logging.hpp"
+
+template <typename T>
+inline T *getExportedFieldPointer(const SandHook::ElfImg &libc, const char *name) {
+    auto *addr = reinterpret_cast<T *>(libc.getSymbAddress(name));
+
+    return addr == nullptr ? nullptr : addr;
+}
+
+namespace Atexit {
+
+void AtexitArray::recompact() {
+    if (!needs_recompaction()) {
+        LOGD("needs_recompaction returns false");
+    }
+
+    set_writable(true, 0, size_);
+
+    // Optimization: quickly skip over the initial non-null entries.
+    size_t src = 0, dst = 0;
+    while (src < size_ && array_[src].fn != nullptr) {
+        ++src;
+        ++dst;
+    }
+
+    // Shift the non-null entries forward, and zero out the removed entries at the end of the array.
+    for (; src < size_; ++src) {
+        const AtexitEntry entry = array_[src];
+        array_[src] = {};
+        if (entry.fn != nullptr) {
+            array_[dst++] = entry;
+        }
+    }
+
+    // If the table uses fewer pages, clean the pages at the end.
+    size_t old_bytes = page_end_of_index(size_);
+    size_t new_bytes = page_end_of_index(dst);
+    if (new_bytes < old_bytes) {
+        madvise(reinterpret_cast<char *>(array_) + new_bytes, old_bytes - new_bytes, MADV_DONTNEED);
+    }
+
+    set_writable(false, 0, size_);
+
+    size_ = dst;
+    extracted_count_ = 0;
+    total_appends_ = size_;
+}
+
+// Use mprotect to make the array writable or read-only. Returns true on success. Making the array
+// read-only could protect against either unintentional or malicious corruption of the array.
+void AtexitArray::set_writable(bool writable, size_t start_idx, size_t num_entries) {
+    if (array_ == nullptr) return;
+
+    const size_t start_byte = page_start_of_index(start_idx);
+    const size_t stop_byte = page_end_of_index(start_idx + num_entries);
+    const size_t byte_len = stop_byte - start_byte;
+
+    const int prot = PROT_READ | (writable ? PROT_WRITE : 0);
+    if (mprotect(reinterpret_cast<char *>(array_) + start_byte, byte_len, prot) != 0) {
+        PLOGE("mprotect failed on atexit array: %m");
+    }
+}
+
+AtexitArray *findAtexitArray() {
+    SandHook::ElfImg libc("libc.so");
+    auto p_array = getExportedFieldPointer<AtexitEntry *>(libc, "_ZL7g_array.0");
+    auto p_size = getExportedFieldPointer<size_t>(libc, "_ZL7g_array.1");
+    auto p_extracted_count = getExportedFieldPointer<size_t>(libc, "_ZL7g_array.2");
+    auto p_capacity = getExportedFieldPointer<size_t>(libc, "_ZL7g_array.3");
+    auto p_total_appends = getExportedFieldPointer<uint64_t>(libc, "_ZL7g_array.4");
+
+    if (p_array == nullptr || p_size == nullptr || p_extracted_count == nullptr ||
+        p_capacity == nullptr || p_total_appends == nullptr) {
+        LOGD("failed to find exported g_array fields in memory");
+        return nullptr;
+    }
+
+    return reinterpret_cast<AtexitArray *>(p_array);
+}
+
+}  // namespace Atexit

--- a/loader/src/injector/clean.cpp
+++ b/loader/src/injector/clean.cpp
@@ -3,10 +3,19 @@
 
 #include <lsplt.hpp>
 
+#include "atexit.hpp"
 #include "fossil.hpp"
 #include "logging.hpp"
 #include "solist.hpp"
 #include "zygisk.hpp"
+
+void clean_libc_trace() {
+    auto g_array = Atexit::findAtexitArray();
+    if (g_array != nullptr) {
+        g_array->recompact();
+        LOGD("g_array after recompact: %s", g_array->format_state_string().c_str());
+    }
+}
 
 void clean_linker_trace(const char *path, size_t loaded_modules, size_t unloaded_modules,
                         bool unload_soinfo) {

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -322,6 +322,7 @@ void ZygiskContext::run_modules_post() {
 
     if (modules.size() > 0) {
         LOGD("modules unloaded: %zu/%zu", modules_unloaded, modules.size());
+        if (modules.size() == modules_unloaded) clean_libc_trace();
         clean_linker_trace("jit-cache-zygisk", modules.size(), modules_unloaded, true);
         g_hook->should_spoof_maps =
             (flags & APP_SPECIALIZE) && (modules.size() - modules_unloaded) > 0;

--- a/loader/src/injector/zygisk.hpp
+++ b/loader/src/injector/zygisk.hpp
@@ -22,6 +22,8 @@ void hook_entry(void *start_addr, size_t block_size);
 
 void hookJniNativeMethods(JNIEnv *env, const char *clz, JNINativeMethod *methods, int numMethods);
 
+void clean_libc_trace();
+
 void clean_linker_trace(const char *path, size_t loaded_modules, size_t unloaded_modules,
                         bool unload_soinfo);
 


### PR DESCRIPTION
Implements a robust method to evade detection based on the state of libc's global `AtexitArray` object (`g_array`).

### Problem
After Zygisk modules are unloaded via `dlclose`, the `__cxa_finalize` function in libc leaves `g_array.extracted_count_` with a non-zero value. This is a persistent artifact that serves as a reliable detection vector.

### Root Cause
The `recompact()` method, which is responsible for resetting the `extracted_count_`, is not reliably executed. This can be caused by an exception during destructor execution or, more commonly, because the internal `needs_recompaction()` check returns false if the number of unloaded handlers does not cross a memory page boundary.

### Solution
1.  Introduces `AtexitArray`, a proxy class that maps directly onto the memory of the live `g_array` object by finding its members' symbols.
2.  Implements a `recompact()` method in this class that unconditionally compacts the array, bypassing the `needs_recompaction()` check.
3.  To ensure the state is indistinguishable from a non-injected process, this method also resets `total_appends_` to match the new `size_`, in addition to zeroing `extracted_count_`.
4.  A new function, `clean_libc_trace()`, is called after all Zygisk modules have been unloaded to trigger this manual cleaning process.