### PR TITLE
Fix mount namespace caching for 32-bit zygote

### DIFF
--- a/loader/src/common/daemon.cpp
+++ b/loader/src/common/daemon.cpp
@@ -74,13 +74,17 @@ std::string UpdateMountNamespace(MountNamespace type) {
     UniqueFd fd = Connect(1);
     if (fd == -1) {
         PLOGE("UpdateMountNamespace");
-        return "";
+        return "socket not connected";
     }
     socket_utils::write_u8(fd, (uint8_t) SocketAction::UpdateMountNamespace);
     socket_utils::write_u8(fd, (uint8_t) type);
     uint32_t target_pid = socket_utils::read_u32(fd);
     int target_fd = (int) socket_utils::read_u32(fd);
-    if (target_fd == 0) return "";
+    if (target_fd == 0) {
+        // Certainly the case for the first 32bit app process
+        CacheMountNamespace(getpid(), true);
+        return "not cached yet";
+    }
     return "/proc/" + std::to_string(target_pid) + "/fd/" + std::to_string(target_fd);
 }
 

--- a/zygiskd/src/constants.rs
+++ b/zygiskd/src/constants.rs
@@ -61,27 +61,6 @@ pub enum DaemonSocketAction {
     SystemServerStarted,
 }
 
-/// Represents the two types of mount namespaces the daemon manages.
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
-#[repr(u8)]
-pub enum MountNamespace {
-    /// A "clean" namespace with all root-related mounts removed.
-    Clean,
-    /// The root namespace of the system, as seen by Zygote.
-    Root,
-}
-
-impl TryFrom<u8> for MountNamespace {
-    type Error = anyhow::Error;
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(MountNamespace::Clean),
-            1 => Ok(MountNamespace::Root),
-            _ => anyhow::bail!("Invalid MountNamespace value: {}", value),
-        }
-    }
-}
-
 bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     pub struct ProcessFlags: u32 {

--- a/zygiskd/src/main.rs
+++ b/zygiskd/src/main.rs
@@ -73,6 +73,7 @@
 mod companion;
 mod constants;
 mod dl;
+mod mount;
 mod root_impl;
 mod utils;
 mod zygiskd;
@@ -124,7 +125,7 @@ fn start() {
 /// It sets up the environment and launches the core daemon logic.
 fn main_daemon_entry() -> anyhow::Result<()> {
     // We must be in the root mount namespace to function correctly.
-    utils::switch_mount_namespace(1)?;
+    mount::switch_mount_namespace(1)?;
     // Detect and globally set the root implementation.
     root_impl::setup();
     log::info!("Current root implementation: {:?}", root_impl::get());

--- a/zygiskd/src/mount.rs
+++ b/zygiskd/src/mount.rs
@@ -1,0 +1,214 @@
+// src/mount.rs
+
+//! Manages Linux mount namespaces for the NeoZygisk daemon.
+//!
+//! This module provides a unified API for caching, cleaning, and switching
+//! between different mount namespaces, which is crucial for isolating Zygisk
+//! modules and providing them with a clean environment.
+
+use anyhow::{Result, bail};
+use log::{debug, error, trace};
+use procfs::process::{MountInfo, Process};
+use rustix::thread as rustix_thread;
+use std::ffi::CString;
+use std::fs;
+use std::io::Error;
+use std::os::fd::{AsFd, AsRawFd, OwnedFd, RawFd};
+use std::sync::OnceLock;
+
+use crate::root_impl;
+
+/// Represents the two types of mount namespaces the daemon manages.
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[repr(u8)]
+pub enum MountNamespace {
+    /// A "clean" namespace with all root-related mounts removed.
+    Clean,
+    /// The root namespace of the system, as seen by Zygote.
+    Root,
+}
+
+impl TryFrom<u8> for MountNamespace {
+    type Error = anyhow::Error;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(MountNamespace::Clean),
+            1 => Ok(MountNamespace::Root),
+            _ => anyhow::bail!("Invalid MountNamespace value: {}", value),
+        }
+    }
+}
+
+/// Switches the current thread into the mount namespace of a given process.
+pub fn switch_mount_namespace(pid: i32) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let mnt_ns_file = fs::File::open(format!("/proc/{}/ns/mnt", pid))?;
+    rustix_thread::move_into_link_name_space(
+        mnt_ns_file.as_fd(),
+        Some(rustix_thread::LinkNameSpaceType::Mount),
+    )?;
+    // `setns` can change the current working directory, so we restore it.
+    std::env::set_current_dir(cwd)?;
+    Ok(())
+}
+
+/// Manages the lifecycle and caching of mount namespace file descriptors.
+///
+/// This manager is responsible for creating and holding onto file descriptors
+/// that represent specific mount namespaces, preventing them from being destroyed.
+pub struct MountNamespaceManager {
+    clean_mnt_ns_fd: OnceLock<OwnedFd>,
+    root_mnt_ns_fd: OnceLock<OwnedFd>,
+}
+
+impl MountNamespaceManager {
+    /// Creates a new, empty `MountNamespaceManager`.
+    pub fn new() -> Self {
+        Self {
+            clean_mnt_ns_fd: OnceLock::new(),
+            root_mnt_ns_fd: OnceLock::new(),
+        }
+    }
+
+    fn get_namespace_storage(&self, namespace_type: MountNamespace) -> &OnceLock<OwnedFd> {
+        match namespace_type {
+            MountNamespace::Clean => &self.clean_mnt_ns_fd,
+            MountNamespace::Root => &self.root_mnt_ns_fd,
+        }
+    }
+
+    /// Gets the cached file descriptor for a given namespace type, if it exists.
+    pub fn get_namespace_fd(&self, namespace_type: MountNamespace) -> Option<RawFd> {
+        self.get_namespace_storage(namespace_type)
+            .get()
+            .map(|fd| fd.as_raw_fd())
+    }
+
+    /// Caches a handle to a specific mount namespace (`Clean` or `Root`).
+    ///
+    /// # Arguments
+    /// * `pid` - The PID of a process currently in the target mount namespace.
+    /// * `namespace_type` - The type of namespace to save.
+    pub fn save_mount_namespace(&self, pid: i32, namespace_type: MountNamespace) -> Result<RawFd> {
+        let ns_fd_cell = self.get_namespace_storage(namespace_type);
+        if let Some(fd) = ns_fd_cell.get() {
+            return Ok(fd.as_raw_fd());
+        }
+
+        // Create a pipe for synchronization between parent and child.
+        let (pipe_reader, pipe_writer) = rustix::pipe::pipe()?;
+
+        match unsafe { libc::fork() } {
+            0 => {
+                // --- Child Process ---
+                drop(pipe_reader); // Close the side of the pipe we don't use.
+                switch_mount_namespace(pid).unwrap();
+
+                if namespace_type == MountNamespace::Clean {
+                    // Create a new, private mount namespace for ourselves.
+                    unsafe {
+                        rustix_thread::unshare_unsafe(rustix_thread::UnshareFlags::NEWNS).unwrap();
+                    }
+                    // Unmount all root and module mounts.
+                    Self::clean_mount_namespace().unwrap();
+                }
+
+                // Signal to the parent that setup is complete.
+                let sig: [u8; 1] = [0];
+                rustix::io::write(pipe_writer, &sig).unwrap();
+
+                // Wait indefinitely. The parent will kill us after it has the FD.
+                loop {
+                    std::thread::sleep(std::time::Duration::from_secs(60));
+                }
+            }
+            child_pid if child_pid > 0 => {
+                // --- Parent Process ---
+                drop(pipe_writer);
+
+                // Wait for the signal from the child.
+                let mut buf: [u8; 1] = [0];
+                rustix::io::read(pipe_reader, &mut buf)?;
+                trace!("Child {} finished setting up mount namespace.", child_pid);
+
+                let ns_path = format!("/proc/{}/ns/mnt", child_pid);
+                let ns_file = fs::File::open(&ns_path)?;
+
+                // We have the FD, we can now terminate the child process.
+                unsafe {
+                    libc::kill(child_pid, libc::SIGKILL);
+                    libc::waitpid(child_pid, std::ptr::null_mut(), 0);
+                }
+
+                let raw_fd = ns_file.as_raw_fd();
+                ns_fd_cell
+                    .set(ns_file.into())
+                    .map_err(|_| anyhow::anyhow!("Failed to set OnceLock for namespace FD"))?;
+
+                trace!("{:?} namespace cached as FD {}", namespace_type, raw_fd);
+                Ok(raw_fd)
+            }
+            _ => bail!(Error::last_os_error()),
+        }
+    }
+
+    /// Unmounts filesystems related to root solutions from the current mount namespace.
+    fn clean_mount_namespace() -> Result<()> {
+        let mount_infos = Process::myself()?.mountinfo()?;
+        let mut unmount_targets: Vec<MountInfo> = Vec::new();
+
+        let root_source = match root_impl::get() {
+            root_impl::RootImpl::APatch => Some("APatch"),
+            root_impl::RootImpl::KernelSU => Some("KSU"),
+            root_impl::RootImpl::Magisk => Some("magisk"),
+            _ => None,
+        };
+
+        let ksu_module_source: Option<String> =
+            if matches!(root_impl::get(), root_impl::RootImpl::KernelSU) {
+                mount_infos
+                    .iter()
+                    .find(|info| info.mount_point.as_path().to_str() == Some("/data/adb/modules"))
+                    .and_then(|info| info.mount_source.clone())
+                    .filter(|source| source.starts_with("/dev/block/loop"))
+            } else {
+                None
+            };
+
+        for info in mount_infos {
+            let path_str = info.mount_point.to_str().unwrap_or("");
+            let mount_source_str = info.mount_source.as_deref();
+
+            let should_unmount = info.root.starts_with("/adb/modules")
+                || path_str.starts_with("/data/adb/modules")
+                || (root_source.is_some() && mount_source_str == root_source)
+                || (ksu_module_source.is_some() && info.mount_source == ksu_module_source);
+
+            if should_unmount {
+                unmount_targets.push(info);
+            }
+        }
+
+        // Unmount in reverse order of mnt_id to handle nested mounts correctly.
+        unmount_targets.sort_by_key(|a| std::cmp::Reverse(a.mnt_id));
+
+        for target in unmount_targets {
+            let path = target.mount_point.to_str().unwrap_or("");
+            debug!("Unmounting {} (mnt_id: {})", path, target.mnt_id);
+            if let Ok(path_cstr) = CString::new(path.to_string()) {
+                unsafe {
+                    if libc::umount2(path_cstr.as_ptr(), libc::MNT_DETACH) == -1 {
+                        error!("Failed to unmount {}: {}", path, Error::last_os_error());
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Default for MountNamespaceManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
This commit resolves a critical bug of commit 1d46b68a2d1cd5379f144b8100b58838b1dd5d18 where the mount namespace was never cached for the 32-bit zygote, only for the 64-bit one.

The fix is implemented in the C++ loader layer. When the first 32-bit process requests a namespace update, `zygiskd` now intentionally returns an invalid file descriptor (0). The client-side `UpdateMountNamespace` function detects this special return value and correctly interprets it as a one-time trigger to explicitly cache the 32-bit zygote's mount namespace.

This logic mirrors the existing mechanism for the 64-bit zygote, where the system server (considered as the first 64-bit "app process") performs the initial caching. This change makes the design consistent across both architectures.

To improve code quality, the `zygiskd` (Rust) layer has been refactored:

- All mount namespace management logic has been extracted from utils.rs into a new, dedicated mount.rs module.

- A MountNamespaceManager struct has been introduced to encapsulate the state and logic for caching and retrieving namespace file descriptors, providing a cleaner and more robust API.