### PR TITLE
Simplify mount namespace caching logic

### DIFF
--- a/loader/src/include/daemon.hpp
+++ b/loader/src/include/daemon.hpp
@@ -79,7 +79,7 @@ std::vector<Module> ReadModules();
 
 uint32_t GetProcessFlags(uid_t uid);
 
-void CacheMountNamespace(pid_t pid, bool forced = false);
+void CacheMountNamespace(pid_t pid);
 
 std::string UpdateMountNamespace(MountNamespace type);
 

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -371,7 +371,6 @@ void ZygiskContext::app_specialize_post() {
 void ZygiskContext::server_specialize_pre() {
     run_modules_pre();
     zygiskd::SystemServerStarted();
-    zygiskd::CacheMountNamespace(getpid());
 }
 
 void ZygiskContext::server_specialize_post() { run_modules_post(); }
@@ -408,6 +407,7 @@ void ZygiskContext::nativeForkSystemServer_pre() {
     fork_pre();
     if (is_child()) {
         server_specialize_pre();
+        zygiskd::CacheMountNamespace(getpid());
     }
     sanitize_fds();
 }
@@ -420,7 +420,7 @@ void ZygiskContext::nativeForkSystemServer_post() {
     fork_post();
 }
 
-static bool abort_zygote_unmount(const std::vector<mount_info> &traces, uint32_t info_flags) {
+bool abort_zygote_unmount(const std::vector<mount_info> &traces, uint32_t info_flags) {
     if (traces.size() == 0) {
         LOGV("abort unmounting zygote with an empty trace list");
         return true;
@@ -486,18 +486,19 @@ void ZygiskContext::nativeForkAndSpecialize_post() {
 // -----------------------------------------------------------------
 
 bool ZygiskContext::update_mount_namespace(zygiskd::MountNamespace namespace_type) {
+    LOGV("updating mount namespace to type %s",
+         namespace_type == zygiskd::MountNamespace::Clean ? "Clean" : "Root");
     std::string ns_path = zygiskd::UpdateMountNamespace(namespace_type);
     if (!ns_path.starts_with("/proc/")) {
-        PLOGE("update mount namespace [%s]", ns_path.data());
+        LOGE("invalid mount namespace path: %s", ns_path.data());
         return false;
     }
 
     auto updated_ns = open(ns_path.data(), O_RDONLY);
     if (updated_ns >= 0) {
-        LOGV("set mount namespace to [%s] fd=[%d]", ns_path.data(), updated_ns);
         setns(updated_ns, CLONE_NEWNS);
     } else {
-        PLOGE("open mount namespace [%s]", ns_path.data());
+        PLOGE("open mount namespace path [%s]", ns_path.data());
         return false;
     }
     close(updated_ns);

--- a/zygiskd/src/constants.rs
+++ b/zygiskd/src/constants.rs
@@ -61,27 +61,6 @@ pub enum DaemonSocketAction {
     SystemServerStarted,
 }
 
-/// Represents the two types of mount namespaces the daemon manages.
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
-#[repr(u8)]
-pub enum MountNamespace {
-    /// A "clean" namespace with all root-related mounts removed.
-    Clean,
-    /// The root namespace of the system, as seen by Zygote.
-    Root,
-}
-
-impl TryFrom<u8> for MountNamespace {
-    type Error = anyhow::Error;
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(MountNamespace::Clean),
-            1 => Ok(MountNamespace::Root),
-            _ => anyhow::bail!("Invalid MountNamespace value: {}", value),
-        }
-    }
-}
-
 bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     pub struct ProcessFlags: u32 {

--- a/zygiskd/src/main.rs
+++ b/zygiskd/src/main.rs
@@ -73,6 +73,7 @@
 mod companion;
 mod constants;
 mod dl;
+mod mount;
 mod root_impl;
 mod utils;
 mod zygiskd;
@@ -124,7 +125,7 @@ fn start() {
 /// It sets up the environment and launches the core daemon logic.
 fn main_daemon_entry() -> anyhow::Result<()> {
     // We must be in the root mount namespace to function correctly.
-    utils::switch_mount_namespace(1)?;
+    mount::switch_mount_namespace(1)?;
     // Detect and globally set the root implementation.
     root_impl::setup();
     log::info!("Current root implementation: {:?}", root_impl::get());

--- a/zygiskd/src/mount.rs
+++ b/zygiskd/src/mount.rs
@@ -1,0 +1,214 @@
+// src/mount.rs
+
+//! Manages Linux mount namespaces for the NeoZygisk daemon.
+//!
+//! This module provides a unified API for caching, cleaning, and switching
+//! between different mount namespaces, which is crucial for isolating Zygisk
+//! modules and providing them with a clean environment.
+
+use anyhow::{Result, bail};
+use log::{debug, error, trace};
+use procfs::process::{MountInfo, Process};
+use rustix::thread as rustix_thread;
+use std::ffi::CString;
+use std::fs;
+use std::io::Error;
+use std::os::fd::{AsFd, AsRawFd, OwnedFd, RawFd};
+use std::sync::OnceLock;
+
+use crate::root_impl;
+
+/// Represents the two types of mount namespaces the daemon manages.
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+#[repr(u8)]
+pub enum MountNamespace {
+    /// A "clean" namespace with all root-related mounts removed.
+    Clean,
+    /// The root namespace of the system, as seen by Zygote.
+    Root,
+}
+
+impl TryFrom<u8> for MountNamespace {
+    type Error = anyhow::Error;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(MountNamespace::Clean),
+            1 => Ok(MountNamespace::Root),
+            _ => anyhow::bail!("Invalid MountNamespace value: {}", value),
+        }
+    }
+}
+
+/// Switches the current thread into the mount namespace of a given process.
+pub fn switch_mount_namespace(pid: i32) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let mnt_ns_file = fs::File::open(format!("/proc/{}/ns/mnt", pid))?;
+    rustix_thread::move_into_link_name_space(
+        mnt_ns_file.as_fd(),
+        Some(rustix_thread::LinkNameSpaceType::Mount),
+    )?;
+    // `setns` can change the current working directory, so we restore it.
+    std::env::set_current_dir(cwd)?;
+    Ok(())
+}
+
+/// Manages the lifecycle and caching of mount namespace file descriptors.
+///
+/// This manager is responsible for creating and holding onto file descriptors
+/// that represent specific mount namespaces, preventing them from being destroyed.
+pub struct MountNamespaceManager {
+    clean_mnt_ns_fd: OnceLock<OwnedFd>,
+    root_mnt_ns_fd: OnceLock<OwnedFd>,
+}
+
+impl MountNamespaceManager {
+    /// Creates a new, empty `MountNamespaceManager`.
+    pub fn new() -> Self {
+        Self {
+            clean_mnt_ns_fd: OnceLock::new(),
+            root_mnt_ns_fd: OnceLock::new(),
+        }
+    }
+
+    fn get_namespace_storage(&self, namespace_type: MountNamespace) -> &OnceLock<OwnedFd> {
+        match namespace_type {
+            MountNamespace::Clean => &self.clean_mnt_ns_fd,
+            MountNamespace::Root => &self.root_mnt_ns_fd,
+        }
+    }
+
+    /// Gets the cached file descriptor for a given namespace type, if it exists.
+    pub fn get_namespace_fd(&self, namespace_type: MountNamespace) -> Option<RawFd> {
+        self.get_namespace_storage(namespace_type)
+            .get()
+            .map(|fd| fd.as_raw_fd())
+    }
+
+    /// Caches a handle to a specific mount namespace (`Clean` or `Root`).
+    ///
+    /// # Arguments
+    /// * `pid` - The PID of a process currently in the target mount namespace.
+    /// * `namespace_type` - The type of namespace to save.
+    pub fn save_mount_namespace(&self, pid: i32, namespace_type: MountNamespace) -> Result<RawFd> {
+        let ns_fd_cell = self.get_namespace_storage(namespace_type);
+        if let Some(fd) = ns_fd_cell.get() {
+            return Ok(fd.as_raw_fd());
+        }
+
+        // Create a pipe for synchronization between parent and child.
+        let (pipe_reader, pipe_writer) = rustix::pipe::pipe()?;
+
+        match unsafe { libc::fork() } {
+            0 => {
+                // --- Child Process ---
+                drop(pipe_reader); // Close the side of the pipe we don't use.
+                switch_mount_namespace(pid).unwrap();
+
+                if namespace_type == MountNamespace::Clean {
+                    // Create a new, private mount namespace for ourselves.
+                    unsafe {
+                        rustix_thread::unshare_unsafe(rustix_thread::UnshareFlags::NEWNS).unwrap();
+                    }
+                    // Unmount all root and module mounts.
+                    Self::clean_mount_namespace().unwrap();
+                }
+
+                // Signal to the parent that setup is complete.
+                let sig: [u8; 1] = [0];
+                rustix::io::write(pipe_writer, &sig).unwrap();
+
+                // Wait indefinitely. The parent will kill us after it has the FD.
+                loop {
+                    std::thread::sleep(std::time::Duration::from_secs(60));
+                }
+            }
+            child_pid if child_pid > 0 => {
+                // --- Parent Process ---
+                drop(pipe_writer);
+
+                // Wait for the signal from the child.
+                let mut buf: [u8; 1] = [0];
+                rustix::io::read(pipe_reader, &mut buf)?;
+                trace!("Child {} finished setting up mount namespace.", child_pid);
+
+                let ns_path = format!("/proc/{}/ns/mnt", child_pid);
+                let ns_file = fs::File::open(&ns_path)?;
+
+                // We have the FD, we can now terminate the child process.
+                unsafe {
+                    libc::kill(child_pid, libc::SIGKILL);
+                    libc::waitpid(child_pid, std::ptr::null_mut(), 0);
+                }
+
+                let raw_fd = ns_file.as_raw_fd();
+                ns_fd_cell
+                    .set(ns_file.into())
+                    .map_err(|_| anyhow::anyhow!("Failed to set OnceLock for namespace FD"))?;
+
+                trace!("{:?} namespace cached as FD {}", namespace_type, raw_fd);
+                Ok(raw_fd)
+            }
+            _ => bail!(Error::last_os_error()),
+        }
+    }
+
+    /// Unmounts filesystems related to root solutions from the current mount namespace.
+    fn clean_mount_namespace() -> Result<()> {
+        let mount_infos = Process::myself()?.mountinfo()?;
+        let mut unmount_targets: Vec<MountInfo> = Vec::new();
+
+        let root_source = match root_impl::get() {
+            root_impl::RootImpl::APatch => Some("APatch"),
+            root_impl::RootImpl::KernelSU => Some("KSU"),
+            root_impl::RootImpl::Magisk => Some("magisk"),
+            _ => None,
+        };
+
+        let ksu_module_source: Option<String> =
+            if matches!(root_impl::get(), root_impl::RootImpl::KernelSU) {
+                mount_infos
+                    .iter()
+                    .find(|info| info.mount_point.as_path().to_str() == Some("/data/adb/modules"))
+                    .and_then(|info| info.mount_source.clone())
+                    .filter(|source| source.starts_with("/dev/block/loop"))
+            } else {
+                None
+            };
+
+        for info in mount_infos {
+            let path_str = info.mount_point.to_str().unwrap_or("");
+            let mount_source_str = info.mount_source.as_deref();
+
+            let should_unmount = info.root.starts_with("/adb/modules")
+                || path_str.starts_with("/data/adb/modules")
+                || (root_source.is_some() && mount_source_str == root_source)
+                || (ksu_module_source.is_some() && info.mount_source == ksu_module_source);
+
+            if should_unmount {
+                unmount_targets.push(info);
+            }
+        }
+
+        // Unmount in reverse order of mnt_id to handle nested mounts correctly.
+        unmount_targets.sort_by_key(|a| std::cmp::Reverse(a.mnt_id));
+
+        for target in unmount_targets {
+            let path = target.mount_point.to_str().unwrap_or("");
+            debug!("Unmounting {} (mnt_id: {})", path, target.mnt_id);
+            if let Ok(path_cstr) = CString::new(path.to_string()) {
+                unsafe {
+                    if libc::umount2(path_cstr.as_ptr(), libc::MNT_DETACH) == -1 {
+                        error!("Failed to unmount {}: {}", path, Error::last_os_error());
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Default for MountNamespaceManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
This commit includes aim to improve the robustness and structure of mount namespace caching.

**Rust Daemon (`zygiskd`):**
- Centralizes all mount namespace logic into a new `mount.rs` module.
- Introduces `MountNamespaceManager` to encapsulate state and remove the need for global static FDs.
- The daemon context now owns the manager, making it the single source of truth for namespace caching.

**C++ Client (`loader`):**
- Simplifies the `CacheMountNamespace` API by removing the `forced` parameter, delegating all caching logic to the daemon.
- Relocates the `CacheMountNamespace` call to `nativeForkSystemServer_pre` to ensure more reliable timing.
- Improves error reporting in `UpdateMountNamespace` by returning descriptive strings instead of empty ones.