### PR TITLE
Update SELinux policy to read mount namespace

### DIFF
--- a/module/src/sepolicy.rule
+++ b/module/src/sepolicy.rule
@@ -14,3 +14,4 @@ allow system_server system_server process execmem
 allow zygote tmpfs file *
 allow zygote appdomain_tmpfs file *
 allow zygote proc file *
+allow zygote nsfs file *


### PR DESCRIPTION
The following SELinux audit logs are observed on AVD emulated devices (based on qemu):
```
auditd  : type=1400 audit(0.0:9): avc:  denied  { read } for  comm="main" path="mnt:[4026532964]" dev="nsfs" ino=4026532964 scontext=u:r:zygote:s0 tcontext=u:object_r
```
which caused the failure of NeoZygisk updating mount namespace of root process.