### PR TITLE
Set TMP_PATH env programmatically

### DIFF
--- a/loader/build.gradle.kts
+++ b/loader/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 val verCode: Int by rootProject.extra
 val verName: String by rootProject.extra
 val commitHash: String by rootProject.extra
+val workDirectory: String by rootProject.extra
 
 fun Project.findInPath(executable: String, property: String): String? {
     val pathEnv = System.getenv("PATH")
@@ -29,7 +30,8 @@ val defaultCFlags = arrayOf(
     "-Wall", "-Wextra",
     "-fno-rtti", "-fno-exceptions",
     "-fno-stack-protector", "-fomit-frame-pointer",
-    "-Wno-builtin-macro-redefined", "-D__FILE__=__FILE_NAME__"
+    "-Wno-builtin-macro-redefined", "-D__FILE__=__FILE_NAME__",
+    "-DWORK_DIRECTORY='\"${workDirectory}\"'"
 )
 
 val releaseFlags = arrayOf(

--- a/loader/src/common/daemon.cpp
+++ b/loader/src/common/daemon.cpp
@@ -10,7 +10,10 @@
 namespace zygiskd {
 static std::string TMP_PATH;
 
-void Init(const char *path) { TMP_PATH = path; }
+void Init(const char *path) {
+    TMP_PATH = path;
+    setenv("TMP_PATH", TMP_PATH.data(), 0);
+}
 
 std::string GetTmpPath() { return TMP_PATH; }
 

--- a/loader/src/ptracer/main.cpp
+++ b/loader/src/ptracer/main.cpp
@@ -18,6 +18,8 @@
 // Use string_view literals for efficient, allocation-free string comparisons.
 using namespace std::string_view_literals;
 
+const char *const kWorkDirectory = WORK_DIRECTORY;
+
 // The main entry point for the monitoring process.
 void init_monitor() {
     LOGI("NeoZygisk %s", ZKSU_VERSION);
@@ -72,7 +74,7 @@ static int handle_version();
  */
 int main(int argc, char **argv) {
     // This initialization is for the daemon's internal logic, not for CLI output.
-    zygiskd::Init(getenv("TMP_PATH"));
+    zygiskd::Init(kWorkDirectory);
 
     if (argc < 2) {
         print_usage(argv[0]);

--- a/module/src/customize.sh
+++ b/module/src/customize.sh
@@ -110,13 +110,11 @@ extract "$ZIPFILE" 'module.prop'     "$MODPATH"
 extract "$ZIPFILE" 'post-fs-data.sh' "$MODPATH"
 extract "$ZIPFILE" 'service.sh'      "$MODPATH"
 extract "$ZIPFILE" 'uninstall.sh'      "$MODPATH"
-extract "$ZIPFILE" 'zygisk-ctl.sh'   "$MODPATH"
 mv "$TMPDIR/sepolicy.rule" "$MODPATH"
 
 mkdir "$MODPATH/bin"
 mkdir "$MODPATH/lib"
 mkdir "$MODPATH/lib64"
-mv "$MODPATH/zygisk-ctl.sh" "$MODPATH/bin/zygisk-ctl"
 
 if [ "$ARCH" = "x86" ]; then
   ui_print "- Extracting x86 libraries"

--- a/module/src/post-fs-data.sh
+++ b/module/src/post-fs-data.sh
@@ -26,7 +26,7 @@ create_sys_perm() {
   chcon u:object_r:system_file:s0 $1
 }
 
-export TMP_PATH=@WORK_DIRECTORY@
+TMP_PATH=@WORK_DIRECTORY@
 
 if [ -d $TMP_PATH ]; then
   rm -rf $TMP_PATH

--- a/module/src/zygisk-ctl.sh
+++ b/module/src/zygisk-ctl.sh
@@ -1,5 +1,0 @@
-MODDIR=${0%/*}/..
-
-export TMP_PATH=@WORK_DIRECTORY@
-
-exec $MODDIR/bin/zygisk-ptrace64 ctl $*


### PR DESCRIPTION
By doing so, we can invoke the binary `bin/zygisk-ptrace64` directly.

The wrapper scirpt `zygisk-ctl.sh` is thus removed.