### PR TITLE
Add standalone mode to trace command for late zygote injection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ val minKsuVersion by extra(10940)
 val minKsudVersion by extra(11425)
 val maxKsuVersion by extra(30000)
 val minMagiskVersion by extra(26402)
-val workDirectory by extra("/data/adb/neozygisk")
+val workDirectory by extra("/data/system/neozygisk")
 val updateJson by extra("https://raw.githubusercontent.com/JingMatrix/NeoZygisk/master/module/zygisk.json")
 
 val androidMinSdkVersion by extra(26)

--- a/docs/late-injection.md
+++ b/docs/late-injection.md
@@ -1,0 +1,231 @@
+# Late Injection Mode
+
+> Status: experimental. This mode is not part of a normal NeoZygisk release.
+> It still requires a permissive SELinux policy to allow the control-socket
+> connection (see [Requirements](#requirements)).
+
+## Overview
+
+NeoZygisk normally bootstraps from the early boot sequence: a `monitor` process is
+started during the root solution's init phase and `ptrace`s zygote before it
+specializes any app. This is impossible in environments where those early
+init-phase hooks are unavailable (for example AOSP `userdebug` builds, or root
+solutions with incomplete boot-stage support) — by the time the module's scripts
+run, zygote and `system_server` are already alive and specialized.
+
+Late injection covers that case by attaching to the already-running processes:
+
+| Mode | Trace target | Purpose |
+| --- | --- | --- |
+| `--spawn` | a freshly restarted zygote | the normal boot-time path (used internally by `monitor`) |
+| `--standalone` | a running `zygote64` / `zygote32` | inject after boot; also starts the daemon control socket |
+| `--system_server` | a running `system_server` | drive a synthetic `server_specialize` for the already-started process |
+
+## How it works
+
+* Attach to a running process. `PTRACE_SEIZE` does not stop a running target, so the
+  tracer issues an explicit `PTRACE_INTERRUPT`, and omits `PTRACE_O_EXITKILL` so the
+  target is never killed if the tracer exits.
+* Resume cleanly. A process interrupted inside a blocking syscall would otherwise hit
+  the kernel's syscall-restart path; the tracer clears the syscall state in the
+  working registers before the remote call and restores the original registers on
+  detach.
+* system_server specialization. Because `system_server` already finished its real
+  specialization, the injected library reconstructs the process state (UID/GID,
+  capabilities, a temporary `JNIEnv`) and fires the Zygisk `server_specialize`
+  lifecycle manually, tagging it with `RuntimeFlags::LATE_INJECT`.
+
+## Requirements
+
+### Permissive SELinux
+
+NeoZygisk depends on a set of custom SELinux rules shipped in
+`module/src/sepolicy.rule` — most importantly executable-memory access for the
+injected hook code (`allow zygote zygote process execmem`,
+`allow system_server system_server process execmem`) and access to the control
+socket (`allow zygote zygisk_file sock_file { read write }`), alongside several file
+and namespace accesses. On a real Magisk/KernelSU/APatch device the root solution
+loads these rules at boot.
+
+The central obstacle to late injection is that these environments provide no
+mechanism to load custom sepolicy rules. Since the rules NeoZygisk requires cannot be
+applied, it cannot run under an enforcing policy, and the device must be set
+permissive (`setenforce 0`).
+
+Relocating the runtime directory under `/data/system` is an attempt to shrink that
+gap: living in an already-accessible domain (`system_data_file`) removes the need for
+the custom file-access rules a `/data/adb` location would otherwise require. It
+cannot, however, grant `execmem` or the socket-connection rule, so it does not lift
+the permissive requirement. In that sense the relocation turns out to be futile — it
+only narrows the missing rule set and documents the attempt; permissive SELinux is
+still mandatory. The security consequence of running without that gate is covered in
+[Security: socket peer admission](#security-socket-peer-admission).
+
+### An emulated Magisk environment
+
+NeoZygisk's daemon identifies the active root solution by invoking the `magisk`
+binary and querying its database (`zygiskd/src/root_impl/magisk.rs`), and module
+scripts routinely call other Magisk-provided utilities. None of these exist on a bare
+AOSP build, so they must be emulated with shims placed on `PATH`. Without the `magisk`
+shim and database the daemon recognizes no root solution and process flags are empty;
+without `unshare`, mount-namespace-sensitive modules — Vector in particular — will not
+run correctly.
+
+A minimal `magisk` shim, placed somewhere on `PATH` so `which magisk` resolves:
+
+```sh
+#!/system/bin/sh
+case "$1" in
+  -v)       echo "30.0:MAGISK" ;;               # variant string, read by `magisk -v`
+  -V)       echo "30000" ;;                     # version code, must be >= MIN_MAGISK_VERSION
+  --sqlite) sqlite3 /data/adb/magisk.db "$2" ;; # database queries
+  *)        exit 1 ;;
+esac
+```
+
+A crafted `/data/adb/magisk.db` providing the tables the daemon reads:
+
+```sql
+CREATE TABLE IF NOT EXISTS policies (uid INT, policy INT, until INT, logging INT, notification INT, PRIMARY KEY(uid));
+CREATE TABLE IF NOT EXISTS denylist (package_name TEXT, process TEXT, PRIMARY KEY(package_name, process));
+CREATE TABLE IF NOT EXISTS settings (key TEXT, value INT, PRIMARY KEY(key));
+CREATE TABLE IF NOT EXISTS strings  (key TEXT, value TEXT, PRIMARY KEY(key));
+
+-- Grant root to a uid (policy 2 == ALLOW), read by uid_granted_root:
+INSERT OR REPLACE INTO policies (uid, policy, until, logging, notification) VALUES (10234, 2, 0, 1, 1);
+
+-- Identify the manager package, read by uid_is_manager via the `requester` key:
+INSERT OR REPLACE INTO strings (key, value) VALUES ('requester', 'com.example.manager');
+```
+
+A `resetprop` shim, mapping Magisk's property tool onto the stock `setprop`/`getprop`
+(module scripts use it to set or clear system properties):
+
+```sh
+#!/system/bin/sh
+delete=0; prop=""; value=""
+while [ "$1" ]; do
+  case "$1" in
+    --delete) delete=1 ;;
+    -*)       ;;                                    # ignore -p/-n and friends
+    *)        [ -z "$prop" ] && prop="$1" || value="$1" ;;
+  esac
+  shift
+done
+[ -z "$prop" ] && exit 0
+[ "$delete" = 1 ] && exec /system/bin/setprop "$prop" "" \
+                  || exec /system/bin/setprop "$prop" "$value"
+```
+
+An `unshare` shim. Magisk ships a GNU-style `unshare` that understands
+`--propagation slave`, which toybox's `unshare` does not; the shim translates it into
+an `rslave` remount. This is required to run Vector correctly:
+
+```sh
+#!/system/bin/sh
+args=""; slave=0
+while [ "$1" ]; do
+  case "$1" in
+    --propagation)              shift; [ "$1" = slave ] && slave=1 ;;
+    -m|-i|-n|-p|-u|-U|-r|-f|-a|-C) args="$args $1" ;;
+    *)                          break ;;            # remainder is the command to run
+  esac
+  shift
+done
+if [ "$slave" = 1 ]; then
+  exec /system/bin/unshare $args /system/bin/sh -c 'mount -o rslave none /; exec "$@"' -- "$@"
+else
+  exec /system/bin/unshare $args "$@"
+fi
+```
+
+## Security: socket peer admission
+
+On an enforcing device the control socket is restricted to the `zygote` domain by
+`sepolicy.rule`, so the connecting process is trusted by construction. Late injection
+requires a permissive policy and a world-accessible (`0777`) socket, which removes that
+gate, so the daemon authenticates peers itself.
+
+Every connection the daemon legitimately accepts is opened while the caller is still
+root or system at `connect()` time: zygote (uid 0) during injection and the whole
+pre-specialization window — module FDs, mount namespaces and the companion *request*
+are all obtained there — system_server (uid 1000) on the late path, and the root tracer
+(uid 0). The loader makes no daemon connection after a process drops to its app uid, and
+the app↔companion channel is a handed-off descriptor that never reconnects to the
+daemon. The daemon therefore admits only peers the kernel reports via `SO_PEERCRED` as
+uid 0 or 1000, and rejects everything else with a warning.
+
+Residual risk: a permissive policy also stops the kernel enforcing SELinux domain
+transitions, so a process that can already run as root or system may still connect and
+supply unverified request data — for example a self-declared app `uid` in
+`GetProcessFlags`, or an out-of-range module `index` in `RequestCompanionSocket` /
+`GetModuleDir` (which is not bounds-checked). This requires the caller to already hold
+root or system — inside the trust boundary — so it is bounded, but it cannot be closed
+while the policy is permissive.
+
+Note for module authors: because the gate admits only root/system peers, a module must
+obtain its companion socket and module directory during `preAppSpecialize` (while still
+privileged), not from `postAppSpecialize` (app uid). This matches the connection model
+documented in `zygiskd/src/main.rs`.
+
+By the way — a companion fd kept open in a target app is also reachable by that app's
+own code. The module and the app share one process and fd table with no isolation
+between them, so the app can enumerate `/proc/self/fd`, recognize the socket (its peer
+is root via `SO_PEERCRED`), and speak the companion protocol itself. A companion is
+therefore root code serving a possibly hostile caller: validate every request, expose
+the narrowest operations you can, and close the fd as soon as the work is done rather
+than parking a root channel in an untrusted process. The fd survives specialization
+only because the module exempts it from `sanitize_fds()` (`api->exemptFd`), so keeping
+it open is a deliberate choice with a deliberate cost.
+
+## Triggering late injection
+
+A minimal post-boot trigger, run from a root shell once the device is fully booted.
+The tracer binary lives at `<module>/bin/zygisk-ptrace64` (or `…32`).
+
+```sh
+# 1. Allow the control-socket connection, and put the shims (magisk, resetprop,
+#    unshare) on PATH so the daemon detects the emulated root solution and module
+#    scripts find the Magisk utilities they expect.
+setenforce 0
+export PATH=/path/to/shims:$PATH
+
+# 2. Inject the running zygote. In --standalone the tracer also forks the
+#    daemon and starts listening on the control socket before injecting.
+./bin/zygisk-ptrace64 trace "$(pidof zygote64)" --standalone &
+
+# 3. Inject the already-running system_server.
+./bin/zygisk-ptrace64 trace "$(pidof system_server)" --system_server
+```
+
+## Module contract
+
+A module can detect that it was started this way and adjust its bootstrap. The flag
+is defined in `loader/src/injector/system_server.hpp`:
+
+```cpp
+enum RuntimeFlags : uint32_t {
+    // Safely out of the way of AOSP's own runtime flag bits.
+    LATE_INJECT = 1 << 30,
+};
+```
+
+```cpp
+// Native Zygisk module
+void onServerSpecialize(ServerSpecializeArgs *args) override {
+    const bool late_inject = args->runtime_flags & RuntimeFlags::LATE_INJECT;
+    if (late_inject) {
+        // The framework is already up: bootstrap manually (resolve the live
+        // ClassLoader, fire boot-completed callbacks, …) instead of relying on
+        // the normal launch sequence.
+    }
+}
+```
+
+A reference module-side implementation lives in Vector (a refactored LSPosed):
+<https://github.com/JingMatrix/Vector/pull/564#issue-4050922152>.
+
+The Vector-side changes are neutral and have been merged. The NeoZygisk-side changes
+remain a pull request, because there is no complete solution for the sepolicy
+requirement and the unverified-input risks documented above are inherent to running
+under a permissive policy.

--- a/loader/src/include/trace.hpp
+++ b/loader/src/include/trace.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+enum TraceMode {
+    UNKNOWN = 0,
+    SPAWN = 1,
+    STANDALONE = 2,
+    SYSTEM_SERVER = 3,
+};
+

--- a/loader/src/injector/entry.cpp
+++ b/loader/src/injector/entry.cpp
@@ -2,6 +2,7 @@
 
 #include "daemon.hpp"
 #include "logging.hpp"
+#include "system_server.hpp"
 #include "trace.hpp"
 #include "zygisk.hpp"
 
@@ -18,10 +19,10 @@ void entry(void* addr, size_t size, const char* path, TraceMode mode) {
         return;
     }
 
-    hook_entry(addr, size);
     if (mode == TraceMode::SYSTEM_SERVER) {
-        LOGI("preparing to invoke modules for system_server");
+        trigger_system_server_hooks();
     } else {
+        hook_entry(addr, size);
         send_seccomp_event_if_needed();
     }
 

--- a/loader/src/injector/entry.cpp
+++ b/loader/src/injector/entry.cpp
@@ -2,13 +2,14 @@
 
 #include "daemon.hpp"
 #include "logging.hpp"
+#include "trace.hpp"
 #include "zygisk.hpp"
 
 using namespace std;
 
 extern "C" [[gnu::visibility("default")]]
-void entry(void* addr, size_t size, const char* path) {
-    LOGI("zygisk library injected, version %s", ZKSU_VERSION);
+void entry(void* addr, size_t size, const char* path, TraceMode mode) {
+    LOGI("zygisk library injected, version %s [mode: %d]", ZKSU_VERSION, mode);
 
     zygiskd::Init(path);
 
@@ -18,7 +19,16 @@ void entry(void* addr, size_t size, const char* path) {
     }
 
     hook_entry(addr, size);
-    send_seccomp_event_if_needed();
+    if (mode == TraceMode::SYSTEM_SERVER) {
+        LOGI("preparing to invoke modules for system_server");
+    } else {
+        send_seccomp_event_if_needed();
+    }
+
+    // Tiggering Zygote hooks
+    if (mode == TraceMode::STANDALONE) {
+        trigger_zygote_hooks();
+    }
 }
 
 /**

--- a/loader/src/injector/hook.cpp
+++ b/loader/src/injector/hook.cpp
@@ -14,6 +14,8 @@
 #include "module.hpp"
 #include "zygisk.hpp"
 
+#define PROP_VALUE_MAX 92
+
 using namespace std;
 
 // *********************
@@ -174,6 +176,13 @@ DCL_HOOK_FUNC(static int, pthread_attr_setstacksize, void *target, size_t size) 
 }
 
 #undef DCL_HOOK_FUNC
+
+void trigger_zygote_hooks() {
+    LOGI("triggering zygote hook sequence");
+    new_strdup(kZygoteInit);
+    char buf[PROP_VALUE_MAX];
+    new_property_get("ro.product.cpu.abi", buf, "0");
+}
 
 // -----------------------------------------------------------------
 static size_t get_fd_max() {

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -320,13 +320,12 @@ void ZygiskContext::run_modules_post() {
         if (m.tryUnload()) modules_unloaded++;
     }
 
-    if (modules.size() > 0) {
+    if (modules.size() > 0 && g_hook != nullptr) {
         LOGV("modules unloaded: %zu/%zu", modules_unloaded, modules.size());
         if (modules.size() == modules_unloaded) clean_libc_trace();
         clean_linker_trace("jit-cache-zygisk", modules.size(), modules_unloaded, true);
-        if (g_hook != nullptr)
-            g_hook->should_spoof_maps =
-                (flags & APP_SPECIALIZE) && (modules.size() - modules_unloaded) > 0;
+        g_hook->should_spoof_maps =
+            (flags & APP_SPECIALIZE) && (modules.size() - modules_unloaded) > 0;
     }
 }
 

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -324,8 +324,9 @@ void ZygiskContext::run_modules_post() {
         LOGV("modules unloaded: %zu/%zu", modules_unloaded, modules.size());
         if (modules.size() == modules_unloaded) clean_libc_trace();
         clean_linker_trace("jit-cache-zygisk", modules.size(), modules_unloaded, true);
-        g_hook->should_spoof_maps =
-            (flags & APP_SPECIALIZE) && (modules.size() - modules_unloaded) > 0;
+        if (g_hook != nullptr)
+            g_hook->should_spoof_maps =
+                (flags & APP_SPECIALIZE) && (modules.size() - modules_unloaded) > 0;
     }
 }
 

--- a/loader/src/injector/system_server.cpp
+++ b/loader/src/injector/system_server.cpp
@@ -147,7 +147,7 @@ void trigger_system_server_hooks() {
     jint uid = static_cast<jint>(getuid());
     jint gid = static_cast<jint>(getgid());
     jintArray gids = fetch_gids(env);
-    jint runtime_flags = 0;
+    jint runtime_flags = RuntimeFlags::LATE_INJECT;
     jlong permitted_capabilities = 0;
     jlong effective_capabilities = 0;
 

--- a/loader/src/injector/system_server.cpp
+++ b/loader/src/injector/system_server.cpp
@@ -1,0 +1,173 @@
+#include "system_server.hpp"
+
+#include <dlfcn.h>
+#include <jni.h>
+#include <linux/capability.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <vector>
+
+#include "logging.hpp"
+#include "module.hpp"
+
+namespace {
+
+/**
+ * @brief RAII wrapper to safely obtain JNIEnv and manage thread attachment lifecycle.
+ */
+class JniAttachment {
+public:
+    JniAttachment() {
+        // auto cached_map_infos = lsplt::MapInfo::Scan();
+        // void* libart;
+        // for (auto& map : cached_map_infos) {
+        //     if (map.path.ends_with("/libart.so")) {
+        //         LOGV("found path %s", map.path.data());
+        //         libart = dlopen(map.path.data(), RTLD_NOLOAD | RTLD_NOW);
+        //         if (!libart) {
+        //             libart = dlopen("libart.so", RTLD_NOW);
+        //         }
+        //         break;
+        //     }
+        // }
+
+        // if (!libart) {
+        //     LOGE("failed to get libart.so handle");
+        //     return;
+        // }
+
+        using JNI_GetCreatedJavaVMs_t = jint (*)(JavaVM**, jsize, jsize*);
+
+        // Pass RTLD_DEFAULT instead of a specific library handle
+        auto get_vms =
+            reinterpret_cast<JNI_GetCreatedJavaVMs_t>(dlsym(RTLD_DEFAULT, "JNI_GetCreatedJavaVMs"));
+
+        if (!get_vms) {
+            LOGE("failed to find JNI_GetCreatedJavaVMs in libart");
+            return;
+        }
+
+        jsize num_vms = 0;
+        if (get_vms(&vm_, 1, &num_vms) != JNI_OK || num_vms == 0 || !vm_) {
+            LOGE("failed to get created JavaVM");
+            return;
+        }
+
+        jint env_res = vm_->GetEnv(reinterpret_cast<void**>(&env_), JNI_VERSION_1_6);
+        if (env_res == JNI_EDETACHED) {
+            LOGI("current thread is detached from JVM, attaching temporarily...");
+            JavaVMAttachArgs args{JNI_VERSION_1_6, "NeoZygisk-Injector", nullptr};
+            if (vm_->AttachCurrentThread(&env_, &args) == JNI_OK) {
+                attached_ = true;
+            } else {
+                LOGE("failed to attach current thread to JavaVM");
+                env_ = nullptr;
+            }
+        }
+    }
+
+    ~JniAttachment() {
+        if (attached_ && vm_) {
+            LOGV("detaching temporary injector thread from JVM");
+            vm_->DetachCurrentThread();
+        }
+    }
+
+    JNIEnv* get_env() const { return env_; }
+
+private:
+    JavaVM* vm_ = nullptr;
+    JNIEnv* env_ = nullptr;
+    bool attached_ = false;
+};
+
+/**
+ * @brief Retrieves current process capabilities and maps them to jlong.
+ */
+void fetch_capabilities(jlong& permitted, jlong& effective) {
+    struct __user_cap_header_struct capheader;
+    struct __user_cap_data_struct capdata[2];
+    memset(&capheader, 0, sizeof(capheader));
+    memset(&capdata, 0, sizeof(capdata));
+    capheader.version = _LINUX_CAPABILITY_VERSION_3;  // 64-bit caps
+    capheader.pid = 0;                                // Self
+
+    if (syscall(__NR_capget, &capheader, &capdata) == 0) {
+        permitted = (static_cast<jlong>(capdata[1].permitted) << 32) | capdata[0].permitted;
+        effective = (static_cast<jlong>(capdata[1].effective) << 32) | capdata[0].effective;
+    } else {
+        LOGW("failed to read capabilities via capget, using 0");
+        permitted = 0;
+        effective = 0;
+    }
+}
+
+/**
+ * @brief Retrieves current supplementary groups and allocates a JNI IntArray.
+ */
+jintArray fetch_gids(JNIEnv* env) {
+    int count = getgroups(0, nullptr);
+    if (count <= 0) {
+        return env->NewIntArray(0);
+    }
+
+    std::vector<gid_t> gids(count);
+    getgroups(count, gids.data());
+
+    // Convert gid_t (usually 32-bit unsigned) to jint (32-bit signed)
+    std::vector<jint> j_gids(count);
+    for (int i = 0; i < count; ++i) {
+        j_gids[i] = static_cast<jint>(gids[i]);
+    }
+
+    jintArray array = env->NewIntArray(count);
+    if (array) {
+        env->SetIntArrayRegion(array, 0, count, j_gids.data());
+    }
+    return array;
+}
+
+}  // anonymous namespace
+
+void trigger_system_server_hooks() {
+    LOGI("preparing to invoke modules for system_server");
+
+    // 1. Initialize JVM Context via RAII
+    JniAttachment jni;
+    JNIEnv* env = jni.get_env();
+    if (!env) {
+        LOGE("aborting system_server specialization: failed to obtain JNIEnv");
+        return;
+    }
+
+    // 2. Prepare JNI-compliant variables
+    jint uid = static_cast<jint>(getuid());
+    jint gid = static_cast<jint>(getgid());
+    jintArray gids = fetch_gids(env);
+    jint runtime_flags = 0;
+    jlong permitted_capabilities = 0;
+    jlong effective_capabilities = 0;
+
+    fetch_capabilities(permitted_capabilities, effective_capabilities);
+
+    // 3. Construct the API contract using exact references
+    ServerSpecializeArgs_v1 args(uid, gid, gids, runtime_flags, permitted_capabilities,
+                                 effective_capabilities);
+    ZygiskContext ctx(env, &args);
+
+    // 4. Trigger the Zygisk API lifecycle
+    LOGV("triggering server_specialize_pre");
+    ctx.flags |= SERVER_FORK_AND_SPECIALIZE;
+    ctx.server_specialize_pre();
+
+    LOGV("triggering server_specialize_post");
+    ctx.server_specialize_post();
+
+    // 5. Clean up the local JNI reference to prevent memory leaks in the ART
+    // if (gids) {
+    //     env->DeleteLocalRef(gids);
+    // }
+}

--- a/loader/src/injector/system_server.hpp
+++ b/loader/src/injector/system_server.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+/**
+ * @brief Triggers Zygisk module hooks for system_server in late-injection scenarios.
+ *
+ * Dynamically reconstructs the JNI environment and process state parameters
+ * (UID, GID, capabilities) required to fulfill the Zygisk API contract for
+ * system_server_specialize.
+ */
+void trigger_system_server_hooks();

--- a/loader/src/injector/system_server.hpp
+++ b/loader/src/injector/system_server.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 /**
  * @brief Triggers Zygisk module hooks for system_server in late-injection scenarios.
  *
@@ -8,3 +9,9 @@
  * system_server_specialize.
  */
 void trigger_system_server_hooks();
+
+enum RuntimeFlags : uint32_t {
+    // Safely out of the way of AOSP's flags (Bits 0, 14-26)
+    // https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/jni/com_android_internal_os_Zygote.cpp;
+    LATE_INJECT = 1 << 30,
+};

--- a/loader/src/injector/zygisk.hpp
+++ b/loader/src/injector/zygisk.hpp
@@ -33,4 +33,6 @@ void spoof_zygote_fossil(char *search_from, char *search_to, const char *anchor)
 
 void send_seccomp_event_if_needed();
 
+void trigger_zygote_hooks();
+
 std::vector<mount_info> check_zygote_traces(uint32_t info_flags);

--- a/loader/src/ptracer/main.cpp
+++ b/loader/src/ptracer/main.cpp
@@ -151,7 +151,7 @@ static void print_usage(const char *tool_name) {
     fprintf(stderr, "NeoZygisk Tracer %s\n", ZKSU_VERSION);
     fprintf(
         stderr,
-        "usage: %s monitor | trace <pid> [--restart | --standalone] | ctl <start|stop|exit> | version\n",
+        "usage: %s monitor | trace <pid> [--spwan | --standalone | --system_server] | ctl <start|stop|exit> | version\n",
         tool_name);
 }
 
@@ -193,15 +193,16 @@ static int handle_trace(int argc, char **argv) {
     printf("preparing to trace PID: %d\n", pid);
 
     // --- Flag Parsing ---
-    bool is_restart = false;
-    bool is_standalone = false;
+    TraceMode mode = TraceMode::UNKNOWN;
 
     if (argc >= 4) {
         const auto flag = std::string_view(argv[3]);
-        if (flag == "--restart"sv) {
-            is_restart = true;
+        if (flag == "--spawn"sv) {
+            mode = TraceMode::SPAWN;
         } else if (flag == "--standalone"sv) {
-            is_standalone = true;
+            mode = TraceMode::STANDALONE;
+        } else if (flag == "--system_server"sv) {
+            mode = TraceMode::SYSTEM_SERVER;
         } else {
             fprintf(stderr, "error: unknown flag: '%s'\n", argv[3]);
             print_usage(argv[0]);
@@ -215,10 +216,11 @@ static int handle_trace(int argc, char **argv) {
     signal(SIGTERM, handle_interrupt);
 
     // --- Flag Execution ---
-    if (is_restart) {
-        printf("zygote restart requested...\n");
+    std::string target = "zygote";
+    if (mode == TraceMode::SPAWN) {
+        printf("reporting zygote restart...\n");
         zygiskd::ZygoteRestart();
-    } else if (is_standalone) {
+    } else if (mode == TraceMode::STANDALONE) {
         printf("standalone mode: preparing injection and starting daemon...\n");
 
         auto pid = fork();
@@ -236,18 +238,21 @@ static int handle_trace(int argc, char **argv) {
                 fprintf(stderr, "error: failed to start daemon and prepare injector\n");
                 return EXIT_FAILURE;
             }
-            monitor.run();
+            monitor.run(true, false);
         }
+    } else if (mode == TraceMode::SYSTEM_SERVER) {
+        target = "system_server";
+        printf("injecting into system_server");
     }
 
-    // Call trace_zygote with is_standalone
-    if (!trace_zygote(pid, is_standalone)) {
-        if (!is_standalone) {
+    if (!trace_target(pid, mode)) {
+        if (mode == TraceMode::SPAWN) {
             fprintf(stderr, "error: failed to trace zygote, killing process %d\n", pid);
             kill(pid, SIGKILL);
         } else {
             // In standalone, we just fail gracefully.
-            fprintf(stderr, "error: failed to trace zygote. Process %d left intact.\n", pid);
+            fprintf(stderr, "error: failed to trace %s. Process %d left intact.\n", target.data(),
+                    pid);
             ptrace(PTRACE_DETACH, pid, 0, SIGCONT);
         }
         return EXIT_FAILURE;

--- a/loader/src/ptracer/main.cpp
+++ b/loader/src/ptracer/main.cpp
@@ -1,6 +1,10 @@
 #include "main.hpp"
 
 #include <err.h>
+#include <libgen.h>
+#include <limits.h>
+#include <signal.h>
+#include <sys/ptrace.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -65,6 +69,46 @@ static int handle_trace(int argc, char **argv);
 static int handle_ctl(int argc, char **argv);
 static int handle_version();
 
+// Global variable so our signal handler knows which PID to rescue
+static pid_t g_traced_pid = 0;
+
+/**
+ * @brief Signal handler to safely detach and resume Zygote if the user
+ *        interrupts the standalone tracer (e.g., Ctrl+C).
+ */
+static void handle_interrupt(int sig) {
+    if (g_traced_pid > 0) {
+        printf("\n[!] received signal %d, safely detaching from PID %d to prevent crash...\n", sig,
+               g_traced_pid);
+
+        // PTRACE_DETACH with SIGCONT ensures the process resumes execution
+        ptrace(PTRACE_DETACH, g_traced_pid, 0, SIGCONT);
+    }
+    _exit(EXIT_FAILURE);
+}
+
+/**
+ * @brief Resolves the binary path and changes the working directory to $MODDIR
+ *        ($MODDIR/bin/zygisk-ptrace64 -> $MODDIR)
+ */
+static void cd_to_moddir() {
+    char exe_path[PATH_MAX];
+    ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
+    if (len != -1) {
+        exe_path[len] = '\0';
+        // dirname() modifies the string in place.
+        // First dirname goes from .../bin/zygisk-ptrace64 to .../bin
+        // Second dirname goes from .../bin to .../ (which is $MODDIR)
+        char *mod_dir = dirname(dirname(exe_path));
+
+        if (chdir(mod_dir) == 0) {
+            printf("changed working directory to %s\n", mod_dir);
+        } else {
+            fprintf(stderr, "warning: failed to chdir to %s\n", mod_dir);
+        }
+    }
+}
+
 /**
  * @brief Main entry point for the NeoZygisk command-line interface.
  *
@@ -105,9 +149,10 @@ int main(int argc, char **argv) {
  */
 static void print_usage(const char *tool_name) {
     fprintf(stderr, "NeoZygisk Tracer %s\n", ZKSU_VERSION);
-    fprintf(stderr,
-            "usage: %s monitor | trace <pid> [--restart] | ctl <start|stop|exit> | version\n",
-            tool_name);
+    fprintf(
+        stderr,
+        "usage: %s monitor | trace <pid> [--restart | --standalone] | ctl <start|stop|exit> | version\n",
+        tool_name);
 }
 
 /**
@@ -147,20 +192,69 @@ static int handle_trace(int argc, char **argv) {
     pid_t pid = static_cast<pid_t>(pid_val);
     printf("preparing to trace PID: %d\n", pid);
 
-    // Handle optional --restart flag.
-    if (argc >= 4 && argv[3] == "--restart"sv) {
-        printf("zygote restart requested...\n");
-        zygiskd::ZygoteRestart();
+    // --- Flag Parsing ---
+    bool is_restart = false;
+    bool is_standalone = false;
+
+    if (argc >= 4) {
+        const auto flag = std::string_view(argv[3]);
+        if (flag == "--restart"sv) {
+            is_restart = true;
+        } else if (flag == "--standalone"sv) {
+            is_standalone = true;
+        } else {
+            fprintf(stderr, "error: unknown flag: '%s'\n", argv[3]);
+            print_usage(argv[0]);
+            return EXIT_FAILURE;
+        }
     }
 
-    if (!trace_zygote(pid)) {
-        fprintf(stderr,
-                "error: failed to trace zygote, killing process %d to prevent system instability\n",
-                pid);
-        kill(pid, SIGKILL);
+    // --- Signal Handling for safe exit ---
+    g_traced_pid = pid;
+    signal(SIGINT, handle_interrupt);
+    signal(SIGTERM, handle_interrupt);
+
+    // --- Flag Execution ---
+    if (is_restart) {
+        printf("zygote restart requested...\n");
+        zygiskd::ZygoteRestart();
+    } else if (is_standalone) {
+        printf("standalone mode: preparing injection and starting daemon...\n");
+
+        auto pid = fork();
+        if (pid < 0) {
+            PLOGE("init_monitor");
+            return false;
+        } else if (pid == 0) {
+            // Change directory to $MODDIR BEFORE preparing the injection
+            cd_to_moddir();
+            AppMonitor monitor;
+            if (!monitor.prepare_environment()) {
+                exit(1);
+            }
+            if (monitor.get_abi_manager().check_and_prepare_injection() == nullptr) {
+                fprintf(stderr, "error: failed to start daemon and prepare injector\n");
+                return EXIT_FAILURE;
+            }
+            monitor.run();
+        }
+    }
+
+    // Call trace_zygote with is_standalone
+    if (!trace_zygote(pid, is_standalone)) {
+        if (!is_standalone) {
+            fprintf(stderr, "error: failed to trace zygote, killing process %d\n", pid);
+            kill(pid, SIGKILL);
+        } else {
+            // In standalone, we just fail gracefully.
+            fprintf(stderr, "error: failed to trace zygote. Process %d left intact.\n", pid);
+            ptrace(PTRACE_DETACH, pid, 0, SIGCONT);
+        }
         return EXIT_FAILURE;
     }
 
+    // Success, reset the global PID so we don't accidentally send signals on exit
+    g_traced_pid = 0;
     printf("successfully attached and injected into PID: %d\n", pid);
     return EXIT_SUCCESS;
 }

--- a/loader/src/ptracer/main.hpp
+++ b/loader/src/ptracer/main.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "trace.hpp"
+
 void init_monitor();
-bool trace_zygote(int pid, bool is_standalone);
+bool trace_target(int pid, TraceMode mode);
 
 enum Command {
     START = 1,

--- a/loader/src/ptracer/main.hpp
+++ b/loader/src/ptracer/main.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 void init_monitor();
-bool trace_zygote(int pid);
+bool trace_zygote(int pid, bool is_standalone);
 
 enum Command {
     START = 1,

--- a/loader/src/ptracer/monitor.hpp
+++ b/loader/src/ptracer/monitor.hpp
@@ -110,7 +110,7 @@ public:
 
     // Public Lifecycle Methods
     bool prepare_environment();
-    void run();
+    void run(bool socket_loop = true, bool ptrace_loop = true);
 
     // Public Interface for state changes and notifications
     void update_status();

--- a/loader/src/ptracer/monitor_impl.cpp
+++ b/loader/src/ptracer/monitor_impl.cpp
@@ -132,12 +132,20 @@ bool AppMonitor::prepare_environment() {
     return true;
 }
 
-void AppMonitor::run() {
-    socket_handler_.Init();
-    ptrace_handler_.Init();
+void AppMonitor::run(bool socket_loop, bool ptrace_loop) {
+    if (!socket_loop && !ptrace_loop) {
+        LOGD("No moniter handler actived, exiting...");
+        return;
+    }
     event_loop_.Init();
-    event_loop_.RegisterHandler(socket_handler_, EPOLLIN | EPOLLET);
-    event_loop_.RegisterHandler(ptrace_handler_, EPOLLIN | EPOLLET);
+    if (socket_loop) {
+        socket_handler_.Init();
+        event_loop_.RegisterHandler(socket_handler_, EPOLLIN | EPOLLET);
+    }
+    if (ptrace_loop) {
+        ptrace_handler_.Init();
+        event_loop_.RegisterHandler(ptrace_handler_, EPOLLIN | EPOLLET);
+    }
     event_loop_.Loop();
 }
 
@@ -587,7 +595,7 @@ bool AppMonitor::SigChldHandler::handleExecEvent(int pid, int &status) {
             // Fork and execute the external injector daemon.
             auto p = fork_dont_care();
             if (p == 0) {
-                execl(tracer, basename(tracer), "trace", std::to_string(pid).c_str(), "--restart",
+                execl(tracer, basename(tracer), "trace", std::to_string(pid).c_str(), "--spawn",
                       nullptr);
                 PLOGE("execute injector daemon");
                 kill(pid, SIGKILL);

--- a/loader/src/ptracer/ptracer.cpp
+++ b/loader/src/ptracer/ptracer.cpp
@@ -440,14 +440,14 @@ static bool perform_injection(int pid, TraceMode mode) {
     std::string inject_path = lib_path;
     bool use_temp = false;
 
-    if (mode == TraceMode::SYSTEM_SERVER) {
-        inject_path = copy_to_temp(lib_path);
-        if (inject_path.empty()) {
-            LOGE("aborting injection: could not create accessible library copy");
-            return false;
-        }
-        use_temp = true;
-    }
+    // if (mode == TraceMode::SYSTEM_SERVER) {
+    //     inject_path = copy_to_temp(lib_path);
+    //     if (inject_path.empty()) {
+    //         LOGE("aborting injection: could not create accessible library copy");
+    //         return false;
+    //     }
+    //     use_temp = true;
+    // }
 
     bool success = false;
 

--- a/loader/src/ptracer/ptracer.cpp
+++ b/loader/src/ptracer/ptracer.cpp
@@ -1,10 +1,12 @@
 #include <dlfcn.h>
 #include <elf.h>
+#include <fcntl.h>
 #include <link.h>
 #include <signal.h>
 #include <sys/auxv.h>
 #include <sys/mman.h>
 #include <sys/ptrace.h>
+#include <sys/stat.h>
 #include <sys/system_properties.h>
 #include <sys/uio.h>
 #include <sys/wait.h>
@@ -18,12 +20,14 @@
 
 #include "daemon.hpp"
 #include "logging.hpp"
+#include "main.hpp"
 #include "utils.hpp"
 
 /**
  * @brief Shared logic to remotely load and initialize the injector library.
  */
-static bool execute_remote_injection(int pid, struct user_regs_struct &regs, const char *lib_path) {
+static bool execute_remote_injection(int pid, struct user_regs_struct &regs, const char *lib_path,
+                                     TraceMode mode) {
     auto map = MapInfo::Scan(std::to_string(pid));
     auto local_map = MapInfo::Scan();
     auto libc_return_addr = find_module_return_addr(map, "libc.so");
@@ -43,10 +47,50 @@ static bool execute_remote_injection(int pid, struct user_regs_struct &regs, con
         remote_call(pid, regs, (uintptr_t) dlopen_addr, (uintptr_t) libc_return_addr, args);
 
     if (remote_handle == 0) {
-        // [Keep all your existing dlerror handling logic here...]
-        LOGE("remote call to dlopen failed");
+        LOGE("remote call to dlopen failed, retrieving error message with dlerror");
+
+        auto dlerror_addr = find_func_addr(local_map, map, "libdl.so", "dlerror");
+        if (dlerror_addr == nullptr) {
+            LOGE("could not find address of dlerror; cannot retrieve error string");
+            return false;
+        }
+
+        // Remotely call dlerror() (takes no arguments)
+        args.clear();
+        auto dlerror_str_addr =
+            remote_call(pid, regs, (uintptr_t) dlerror_addr, (uintptr_t) libc_return_addr, args);
+
+        if (dlerror_str_addr == 0) {
+            LOGE("remote call to dlerror returned null");
+            return false;
+        }
+
+        auto strlen_addr = find_func_addr(local_map, map, "libc.so", "strlen");
+        if (strlen_addr == nullptr) {
+            LOGE("could not find address of strlen; cannot measure error string length");
+            return false;
+        }
+
+        // Remotely call strlen(dlerror_str_addr)
+        args.clear();
+        args.push_back(dlerror_str_addr);
+        auto dlerror_len =
+            remote_call(pid, regs, (uintptr_t) strlen_addr, (uintptr_t) libc_return_addr, args);
+
+        if (dlerror_len <= 0) {
+            LOGE("dlerror string length is invalid (%" PRIuPTR ")", dlerror_len);
+            return false;
+        }
+
+        // Read the actual error string from system_server's memory
+        std::string err;
+        err.resize(dlerror_len + 1, 0);
+        read_proc(pid, (uintptr_t) dlerror_str_addr, err.data(), dlerror_len);
+
+        LOGE("dlopen error: %s", err.c_str());
         return false;
     }
+
     LOGI("successfully loaded library via remote dlopen, handle: 0x%" PRIxPTR, remote_handle);
 
     // Remotely call dlsym(handle, "entry")
@@ -88,6 +132,7 @@ static bool execute_remote_injection(int pid, struct user_regs_struct &regs, con
     args.push_back(block_size);
     auto remote_tmp_path = push_string(pid, regs, zygiskd::GetTmpPath().c_str());
     args.push_back((long) remote_tmp_path);
+    args.push_back(mode);
     remote_call(pid, regs, injector_entry, (uintptr_t) libc_return_addr, args);
 
     return true;
@@ -110,8 +155,8 @@ static bool execute_remote_injection(int pid, struct user_regs_struct &regs, con
  *     deliberately invalid address. When the process is resumed, it will immediately trigger a
  *     segmentation fault (`SIGSEGV`), which we, as the tracer, can catch. This is a reliable
  *     way to pause the process at the perfect moment.
- * 4.  **Remote Code Execution**: Once the process is paused, we restore the original entry point.
- *     We then use `ptrace` to execute functions within the target process's context.
+ * 4.  **execute_remote_injection**: Once the process is paused, we restore the original entry
+ * point. We then use `ptrace` to execute functions within the target process's context.
  *     - Remotely call `dlopen()` to load our library.
  *     - Remotely call `dlsym()` to find the address of our library's `entry` function.
  *     - Remotely call our `entry` function to initialize NeoZygisk.
@@ -122,8 +167,8 @@ static bool execute_remote_injection(int pid, struct user_regs_struct &regs, con
  * @param lib_path The absolute path to the shared library to be injected.
  * @return True on successful injection, false otherwise.
  */
-bool inject_on_main(int pid, const char *lib_path) {
-    LOGI("starting library injection for PID: %d, library: %s", pid, lib_path);
+bool inject_before_start(int pid, const char *lib_path, TraceMode mode) {
+    LOGI("starting early library injection for PID: %d, library: %s", pid, lib_path);
 
     // Backup of the target's registers, to be restored before detaching.
     struct user_regs_struct regs{}, backup{};
@@ -259,7 +304,7 @@ bool inject_on_main(int pid, const char *lib_path) {
     // Backup the current registers before we start making remote calls.
     memcpy(&backup, &regs, sizeof(regs));
 
-    if (!execute_remote_injection(pid, regs, lib_path)) {
+    if (!execute_remote_injection(pid, regs, lib_path, mode)) {
         return false;
     }
 
@@ -275,8 +320,8 @@ bool inject_on_main(int pid, const char *lib_path) {
     return true;
 }
 
-bool inject_standalone(int pid, const char *lib_path) {
-    LOGI("starting standalone library injection for PID: %d, library: %s", pid, lib_path);
+bool inject_after_start(int pid, const char *lib_path, TraceMode mode) {
+    LOGI("starting late library injection for PID: %d, library: %s", pid, lib_path);
 
     struct user_regs_struct regs{}, backup{};
     if (!get_regs(pid, regs)) {
@@ -306,9 +351,7 @@ bool inject_standalone(int pid, const char *lib_path) {
 #endif
 
     // Execute the shared remote injection logic
-    if (!execute_remote_injection(pid, regs, lib_path)) {
-        return false;
-    }
+    bool sucess = execute_remote_injection(pid, regs, lib_path, mode);
 
     // Restore State directly.
     // The instruction pointer (REG_IP) is already correct in the backup.
@@ -318,7 +361,7 @@ bool inject_standalone(int pid, const char *lib_path) {
         return false;
     }
 
-    return true;
+    return sucess;
 }
 
 // Macro helper to check for specific ptrace stop events.
@@ -336,26 +379,90 @@ static bool wait_for_process(int pid, int *status) {
 }
 
 /**
+ * @brief Copies the library to a world-readable temporary file to bypass DAC restrictions.
+ * @param src_path The original path (e.g., /data/adb/neozygisk/lib64/libzygisk.so)
+ * @return The path to the temporary file, or an empty string on failure.
+ */
+static std::string copy_to_temp(const std::string &src_path) {
+    char tmp_path[] = "/data/local/tmp/zygisk_XXXXXX.so";
+
+    // mkstemps securely creates the file with a random 6-character string replacing XXXXXX.
+    // The '3' tells it to preserve the ".so" suffix.
+    int fd_out = mkstemps(tmp_path, 3);
+    if (fd_out < 0) {
+        PLOGE("failed to create temporary file in /data/local/tmp");
+        return "";
+    }
+
+    int fd_in = open(src_path.c_str(), O_RDONLY | O_CLOEXEC);
+    if (fd_in < 0) {
+        PLOGE("failed to open source library: %s", src_path.c_str());
+        close(fd_out);
+        unlink(tmp_path);
+        return "";
+    }
+
+    // Copy contents
+    char buf[4096];
+    ssize_t bytes_read;
+    while ((bytes_read = read(fd_in, buf, sizeof(buf))) > 0) {
+        if (write(fd_out, buf, bytes_read) != bytes_read) {
+            PLOGE("failed to write to temporary library");
+            close(fd_in);
+            close(fd_out);
+            unlink(tmp_path);
+            return "";
+        }
+    }
+
+    close(fd_in);
+    close(fd_out);
+
+    // Make the file world-readable (and executable) so UID 1000 (system_server) can load it.
+    if (chmod(tmp_path, 0755) != 0) {
+        PLOGE("failed to chmod temporary library %s", tmp_path);
+    }
+
+    LOGV("created temporary library copy at: %s", tmp_path);
+    return std::string(tmp_path);
+}
+
+/**
  * @brief Injects the Zygisk library into the main thread.
  *
  * Shared logic between Seize and Attach methods.
  */
-static bool perform_injection(int pid, bool is_standalone) {
+static bool perform_injection(int pid, TraceMode mode) {
     std::string lib_path = zygiskd::GetTmpPath();
     lib_path += "/lib" LP_SELECT("", "64") "/libzygisk.so";
+    bool process_started = mode == TraceMode::STANDALONE || mode == TraceMode::SYSTEM_SERVER;
 
-    if (is_standalone) {
-        if (!inject_standalone(pid, lib_path.c_str())) {
-            LOGE("failed to inject standalone library into zygote (PID: %d)", pid);
+    std::string inject_path = lib_path;
+    bool use_temp = false;
+
+    if (mode == TraceMode::SYSTEM_SERVER) {
+        inject_path = copy_to_temp(lib_path);
+        if (inject_path.empty()) {
+            LOGE("aborting injection: could not create accessible library copy");
             return false;
         }
-    } else {
-        if (!inject_on_main(pid, lib_path.c_str())) {
-            LOGE("failed to inject library into zygote main (PID: %d)", pid);
-            return false;
-        }
+        use_temp = true;
     }
-    return true;
+
+    bool success = false;
+
+    if (process_started) {
+        success = inject_after_start(pid, inject_path.c_str(), mode);
+    } else {
+        success = inject_before_start(pid, inject_path.c_str(), mode);
+    }
+
+    if (use_temp) {
+        LOGV("cleaning up temporary library: %s", inject_path.c_str());
+        unlink(inject_path.c_str());
+    }
+
+    return success;
 }
 
 /**
@@ -392,17 +499,19 @@ static bool detach_with_gki_workaround(int pid, int detach_signal) {
 
 // --- Strategy 1: PTRACE_SEIZE (Preferred) ---
 
-static bool trace_with_seize(int pid, bool is_standalone) {
+static bool trace_with_seize(int pid, TraceMode mode) {
     LOGI("attempting trace_seize on PID %d", pid);
 
-    int options = is_standalone ? 0 : PTRACE_O_EXITKILL;
-    // PTRACE_O_EXITKILL ensures Zygote dies if we crash, preventing a zombie state.
+    bool process_started = mode == TraceMode::STANDALONE || mode == TraceMode::SYSTEM_SERVER;
+
+    int options = process_started ? 0 : PTRACE_O_EXITKILL;
+    // PTRACE_O_EXITKILL ensures target dies if we crash, preventing a zombie state.
     if (ptrace(PTRACE_SEIZE, pid, 0, options) == -1) {
         // We do not return false here immediately; we let the caller handle errno.
         return false;
     }
 
-    if (is_standalone) {
+    if (process_started) {
         // PTRACE_SEIZE does NOT stop the process. We must explicitly interrupt it.
         LOGV("standalone mode: sending PTRACE_INTERRUPT to pause the running process");
         if (ptrace(PTRACE_INTERRUPT, pid, 0, 0) == -1) {
@@ -424,20 +533,23 @@ static bool trace_with_seize(int pid, bool is_standalone) {
     // Determine the expected stop signal.
     // Normal flow (already SIGSTOPped): SIGSTOP + PTRACE_EVENT_STOP
     // Standalone (PTRACE_INTERRUPT):    SIGTRAP + PTRACE_EVENT_STOP
-    bool valid_stop = is_standalone ? STOPPED_WITH(SIGTRAP, PTRACE_EVENT_STOP)
-                                    : STOPPED_WITH(SIGSTOP, PTRACE_EVENT_STOP);
+    bool valid_stop = process_started ? STOPPED_WITH(SIGTRAP, PTRACE_EVENT_STOP)
+                                      : STOPPED_WITH(SIGSTOP, PTRACE_EVENT_STOP);
 
     if (valid_stop) {
         // 1. Inject Payload
-        if (!perform_injection(pid, is_standalone)) {
+        if (!perform_injection(pid, mode)) {
             BAIL_AND_DETACH
         }
 
-        if (is_standalone) {
+        if (mode == TraceMode::SYSTEM_SERVER) {
+            LOGV("system_server injected");
+            return true;
+        } else if (mode == TraceMode::STANDALONE) {
             // In standalone mode, we interrupted a running process. It doesn't need
             // a SIGCONT to wake up, just a clean detach.
-            LOGV("injection complete, applying GKI workaround and detaching");
-            return detach_with_gki_workaround(pid, 0);  // 0 means don't inject any signal
+            LOGV("standalone injection complete");
+            return true;
         } else {
             LOGV("injection complete, starting signal continuation sequence");
 
@@ -486,7 +598,7 @@ static bool trace_with_seize(int pid, bool is_standalone) {
 
 // --- Strategy 2: PTRACE_ATTACH (Fallback) ---
 
-static bool trace_with_attach(int pid, bool is_standalone) {
+static bool trace_with_attach(int pid, TraceMode mode) {
     LOGI("falling back to trace_attach on PID %d", pid);
 
     // Classic attach. This sends SIGSTOP to the process immediately.
@@ -505,13 +617,13 @@ static bool trace_with_attach(int pid, bool is_standalone) {
     // Classic ATTACH results in a STOPPED status with SIGSTOP.
     // It does NOT use PTRACE_EVENT_STOP in the status bits usually.
     if (WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP) {
-        if (!is_standalone) {
+        if (mode == TraceMode::SPAWN) {
             // Set EXITKILL for parity with SEIZE
             ptrace(PTRACE_SETOPTIONS, pid, 0, PTRACE_O_EXITKILL);
         }
 
         // 1. Inject Payload
-        if (!perform_injection(pid, is_standalone)) {
+        if (!perform_injection(pid, mode)) {
             ptrace(PTRACE_DETACH, pid, 0, 0);
             return false;
         }
@@ -532,20 +644,19 @@ static bool trace_with_attach(int pid, bool is_standalone) {
 }
 
 /**
- * @brief Attaches to the Zygote process and initiates the injection.
+ * @brief Attaches to the target process and initiates the injection.
  *
  * Tries modern PTRACE_SEIZE first. If that fails with I/O error (EIO),
  * falls back to classic PTRACE_ATTACH.
  *
  * @return True on success, false on failure.
  */
-bool trace_zygote(int pid, bool is_standalone) {
-    LOGI("attaching to zygote (PID: %d) to begin injection (standalone: %s)", pid,
-         is_standalone ? "true" : "false");
+bool trace_target(int pid, TraceMode mode) {
+    LOGI("attaching to process [PID: %d, mode : %d]", pid, mode);
 
     // 1. Try SEIZE (Modern, robust handling of group stops)
-    if (trace_with_seize(pid, is_standalone)) {
-        LOGI("successfully detached from zygote (via SEIZE), NeoZygisk active");
+    if (trace_with_seize(pid, mode)) {
+        LOGI("successfully detached from %d (via SEIZE), NeoZygisk active", pid);
         return true;
     }
 
@@ -555,8 +666,8 @@ bool trace_zygote(int pid, bool is_standalone) {
     if (errno == EIO) {
         LOGW("PTRACE_SEIZE failed with EIO, attempting fallback to PTRACE_ATTACH");
 
-        if (trace_with_attach(pid, is_standalone)) {
-            LOGI("successfully detached from zygote (via ATTACH), NeoZygisk active");
+        if (trace_with_attach(pid, mode)) {
+            LOGI("successfully detached from %d (via ATTACH), NeoZygisk active", pid);
             return true;
         }
     } else {

--- a/loader/src/ptracer/ptracer.cpp
+++ b/loader/src/ptracer/ptracer.cpp
@@ -21,6 +21,79 @@
 #include "utils.hpp"
 
 /**
+ * @brief Shared logic to remotely load and initialize the injector library.
+ */
+static bool execute_remote_injection(int pid, struct user_regs_struct &regs, const char *lib_path) {
+    auto map = MapInfo::Scan(std::to_string(pid));
+    auto local_map = MapInfo::Scan();
+    auto libc_return_addr = find_module_return_addr(map, "libc.so");
+
+    // Remotely call dlopen(lib_path, RTLD_NOW)
+    LOGV("executing remote call to dlopen(\"%s\")", lib_path);
+    auto dlopen_addr = find_func_addr(local_map, map, "libdl.so", "dlopen");
+    if (dlopen_addr == nullptr) {
+        LOGE("could not find address of dlopen in the target process");
+        return false;
+    }
+    std::vector<long> args;
+    auto remote_lib_path = push_string(pid, regs, lib_path);
+    args.push_back((long) remote_lib_path);
+    args.push_back((long) RTLD_NOW);
+    auto remote_handle =
+        remote_call(pid, regs, (uintptr_t) dlopen_addr, (uintptr_t) libc_return_addr, args);
+
+    if (remote_handle == 0) {
+        // [Keep all your existing dlerror handling logic here...]
+        LOGE("remote call to dlopen failed");
+        return false;
+    }
+    LOGI("successfully loaded library via remote dlopen, handle: 0x%" PRIxPTR, remote_handle);
+
+    // Remotely call dlsym(handle, "entry")
+    LOGV("executing remote call to dlsym to find the 'entry' symbol");
+    auto dlsym_addr = find_func_addr(local_map, map, "libdl.so", "dlsym");
+    if (dlsym_addr == nullptr) {
+        LOGE("could not find address of dlsym in the target process");
+        return false;
+    }
+    args.clear();
+    auto remote_entry_str = push_string(pid, regs, "entry");
+    args.push_back(remote_handle);
+    args.push_back((long) remote_entry_str);
+    auto injector_entry =
+        remote_call(pid, regs, (uintptr_t) dlsym_addr, (uintptr_t) libc_return_addr, args);
+
+    if (injector_entry == 0) {
+        LOGE("dlsym failed to find the 'entry' symbol in the injected library");
+        return false;
+    }
+    LOGI("found injector entry point at address 0x%" PRIxPTR, injector_entry);
+
+    // Find the address range of the injected library to pass to its entry function.
+    map = MapInfo::Scan(std::to_string(pid));
+    void *start_addr = nullptr;
+    size_t block_size = 0;
+    for (const auto &info : map) {
+        if (info.path.find("libzygisk.so") != std::string::npos) {
+            if (start_addr == nullptr) start_addr = (void *) info.start;
+            block_size += (info.end - info.start);
+        }
+    }
+    LOGV("found injected library mapped from %p with total size %zu", start_addr, block_size);
+
+    // Remotely call our entry(start_addr, block_size, path) function
+    LOGI("calling the injector's entry function to initialize NeoZygisk");
+    args.clear();
+    args.push_back((uintptr_t) start_addr);
+    args.push_back(block_size);
+    auto remote_tmp_path = push_string(pid, regs, zygiskd::GetTmpPath().c_str());
+    args.push_back((long) remote_tmp_path);
+    remote_call(pid, regs, injector_entry, (uintptr_t) libc_return_addr, args);
+
+    return true;
+}
+
+/**
  * @brief Injects a shared library into a running process at its main entry point.
  *
  * This function orchestrates the core injection logic. It attaches to the target process,
@@ -185,103 +258,60 @@ bool inject_on_main(int pid, const char *lib_path) {
 
     // Backup the current registers before we start making remote calls.
     memcpy(&backup, &regs, sizeof(regs));
-    map = MapInfo::Scan(std::to_string(pid));  // Re-scan maps as they may have changed.
-    auto local_map = MapInfo::Scan();
-    auto libc_return_addr = find_module_return_addr(map, "libc.so");
 
-    // Remotely call dlopen(lib_path, RTLD_NOW)
-    LOGV("executing remote call to dlopen(\"%s\")", lib_path);
-    auto dlopen_addr = find_func_addr(local_map, map, "libdl.so", "dlopen");
-    if (dlopen_addr == nullptr) {
-        LOGE("could not find address of dlopen in the target process");
+    if (!execute_remote_injection(pid, regs, lib_path)) {
         return false;
     }
-    std::vector<long> args;
-    auto remote_lib_path = push_string(pid, regs, lib_path);
-    args.push_back((long) remote_lib_path);
-    args.push_back((long) RTLD_NOW);
-    auto remote_handle =
-        remote_call(pid, regs, (uintptr_t) dlopen_addr, (uintptr_t) libc_return_addr, args);
-
-    if (remote_handle == 0) {
-        LOGE("remote call to dlopen failed, retrieving error message with dlerror");
-        auto dlerror_addr = find_func_addr(local_map, map, "libdl.so", "dlerror");
-        if (dlerror_addr == nullptr) {
-            LOGE("could not find address of dlerror; cannot retrieve error string");
-            return false;
-        }
-        args.clear();
-        auto dlerror_str_addr =
-            remote_call(pid, regs, (uintptr_t) dlerror_addr, (uintptr_t) libc_return_addr, args);
-        if (dlerror_str_addr == 0) {
-            LOGE("remote call to dlerror returned null");
-            return false;
-        }
-        auto strlen_addr = find_func_addr(local_map, map, "libc.so", "strlen");
-        if (strlen_addr == nullptr) {
-            LOGE("could not find address of strlen; cannot measure error string length");
-            return false;
-        }
-        args.clear();
-        args.push_back(dlerror_str_addr);
-        auto dlerror_len =
-            remote_call(pid, regs, (uintptr_t) strlen_addr, (uintptr_t) libc_return_addr, args);
-        if (dlerror_len <= 0) {
-            LOGE("dlerror string length is invalid (%" PRIuPTR ")", dlerror_len);
-            return false;
-        }
-        std::string err;
-        err.resize(dlerror_len + 1, 0);
-        read_proc(pid, (uintptr_t) dlerror_str_addr, err.data(), dlerror_len);
-        LOGE("dlopen error: %s", err.c_str());
-        return false;
-    }
-    LOGI("successfully loaded library via remote dlopen, handle: 0x%" PRIxPTR, remote_handle);
-
-    // Remotely call dlsym(handle, "entry")
-    LOGV("executing remote call to dlsym to find the 'entry' symbol");
-    auto dlsym_addr = find_func_addr(local_map, map, "libdl.so", "dlsym");
-    if (dlsym_addr == nullptr) {
-        LOGE("could not find address of dlsym in the target process");
-        return false;
-    }
-    args.clear();
-    auto remote_entry_str = push_string(pid, regs, "entry");
-    args.push_back(remote_handle);
-    args.push_back((long) remote_entry_str);
-    auto injector_entry =
-        remote_call(pid, regs, (uintptr_t) dlsym_addr, (uintptr_t) libc_return_addr, args);
-
-    if (injector_entry == 0) {
-        LOGE("dlsym failed to find the 'entry' symbol in the injected library");
-        return false;
-    }
-    LOGI("found injector entry point at address 0x%" PRIxPTR, injector_entry);
-
-    // Find the address range of the injected library to pass to its entry function.
-    map = MapInfo::Scan(std::to_string(pid));
-    void *start_addr = nullptr;
-    size_t block_size = 0;
-    for (const auto &info : map) {
-        if (info.path.find("libzygisk.so") != std::string::npos) {
-            if (start_addr == nullptr) start_addr = (void *) info.start;
-            block_size += (info.end - info.start);
-        }
-    }
-    LOGV("found injected library mapped from %p with total size %zu", start_addr, block_size);
-
-    // Remotely call our entry(start_addr, block_size, path) function
-    LOGI("calling the injector's entry function to initialize NeoZygisk");
-    args.clear();
-    args.push_back((uintptr_t) start_addr);
-    args.push_back(block_size);
-    auto remote_tmp_path = push_string(pid, regs, zygiskd::GetTmpPath().c_str());
-    args.push_back((long) remote_tmp_path);
-    remote_call(pid, regs, injector_entry, (uintptr_t) libc_return_addr, args);
 
     // --- Step 5: Restore State ---
     // Set the instruction pointer back to the original entry address and restore all registers.
     backup.REG_IP = (long) entry_addr;
+    LOGI("injection complete, restoring registers before resuming normal execution");
+    if (!set_regs(pid, backup)) {
+        LOGE("failed to restore original registers for PID %d", pid);
+        return false;
+    }
+
+    return true;
+}
+
+bool inject_standalone(int pid, const char *lib_path) {
+    LOGI("starting standalone library injection for PID: %d, library: %s", pid, lib_path);
+
+    struct user_regs_struct regs{}, backup{};
+    if (!get_regs(pid, regs)) {
+        LOGE("failed to get registers for PID %d, injection aborted", pid);
+        return false;
+    }
+
+    // Backup current registers (this includes the current Instruction Pointer).
+    memcpy(&backup, &regs, sizeof(regs));
+
+    // The process was interrupted and is likely sleeping inside a syscall.
+    // If we simply change REG_IP and continue, the kernel's syscall restart logic
+    // will kick in and decrement the instruction pointer by 2 (x86) or 4 (ARM),
+    // throwing execution into invalid padding bytes (SIGTRAP) before dlopen.
+    // We must artificially clear the syscall state from our working registers.
+#if defined(__x86_64__)
+    regs.orig_rax = -1;
+    regs.rax = 0;
+#elif defined(__i386__)
+    regs.orig_eax = -1;
+    regs.eax = 0;
+#elif defined(__arm__)
+    regs.uregs[17] = -1;  // orig_r0
+    regs.uregs[0] = 0;
+#elif defined(__aarch64__)
+    regs.regs[0] = 0;  // Clear x0 to prevent -ERESTARTSYS match in kernel
+#endif
+
+    // Execute the shared remote injection logic
+    if (!execute_remote_injection(pid, regs, lib_path)) {
+        return false;
+    }
+
+    // Restore State directly.
+    // The instruction pointer (REG_IP) is already correct in the backup.
     LOGI("injection complete, restoring registers before resuming normal execution");
     if (!set_regs(pid, backup)) {
         LOGE("failed to restore original registers for PID %d", pid);
@@ -310,13 +340,20 @@ static bool wait_for_process(int pid, int *status) {
  *
  * Shared logic between Seize and Attach methods.
  */
-static bool perform_injection(int pid) {
+static bool perform_injection(int pid, bool is_standalone) {
     std::string lib_path = zygiskd::GetTmpPath();
     lib_path += "/lib" LP_SELECT("", "64") "/libzygisk.so";
 
-    if (!inject_on_main(pid, lib_path.c_str())) {
-        LOGE("failed to inject library into zygote (PID: %d)", pid);
-        return false;
+    if (is_standalone) {
+        if (!inject_standalone(pid, lib_path.c_str())) {
+            LOGE("failed to inject standalone library into zygote (PID: %d)", pid);
+            return false;
+        }
+    } else {
+        if (!inject_on_main(pid, lib_path.c_str())) {
+            LOGE("failed to inject library into zygote main (PID: %d)", pid);
+            return false;
+        }
     }
     return true;
 }
@@ -355,13 +392,24 @@ static bool detach_with_gki_workaround(int pid, int detach_signal) {
 
 // --- Strategy 1: PTRACE_SEIZE (Preferred) ---
 
-static bool trace_with_seize(int pid) {
+static bool trace_with_seize(int pid, bool is_standalone) {
     LOGI("attempting trace_seize on PID %d", pid);
 
+    int options = is_standalone ? 0 : PTRACE_O_EXITKILL;
     // PTRACE_O_EXITKILL ensures Zygote dies if we crash, preventing a zombie state.
-    if (ptrace(PTRACE_SEIZE, pid, 0, PTRACE_O_EXITKILL) == -1) {
+    if (ptrace(PTRACE_SEIZE, pid, 0, options) == -1) {
         // We do not return false here immediately; we let the caller handle errno.
         return false;
+    }
+
+    if (is_standalone) {
+        // PTRACE_SEIZE does NOT stop the process. We must explicitly interrupt it.
+        LOGV("standalone mode: sending PTRACE_INTERRUPT to pause the running process");
+        if (ptrace(PTRACE_INTERRUPT, pid, 0, 0) == -1) {
+            PLOGE("ptrace(PTRACE_INTERRUPT) on PID %d", pid);
+            ptrace(PTRACE_DETACH, pid, 0, 0);
+            return false;
+        }
     }
 
     int status;
@@ -373,47 +421,59 @@ static bool trace_with_seize(int pid) {
     // Wait for the initial Seize stop
     if (!wait_for_process(pid, &status)) return false;
 
-    // SEIZE usually stops with SIGSTOP + PTRACE_EVENT_STOP
-    if (STOPPED_WITH(SIGSTOP, PTRACE_EVENT_STOP)) {
+    // Determine the expected stop signal.
+    // Normal flow (already SIGSTOPped): SIGSTOP + PTRACE_EVENT_STOP
+    // Standalone (PTRACE_INTERRUPT):    SIGTRAP + PTRACE_EVENT_STOP
+    bool valid_stop = is_standalone ? STOPPED_WITH(SIGTRAP, PTRACE_EVENT_STOP)
+                                    : STOPPED_WITH(SIGSTOP, PTRACE_EVENT_STOP);
+
+    if (valid_stop) {
         // 1. Inject Payload
-        if (!perform_injection(pid)) {
+        if (!perform_injection(pid, is_standalone)) {
             BAIL_AND_DETACH
         }
 
-        LOGV("injection complete, starting signal continuation sequence");
+        if (is_standalone) {
+            // In standalone mode, we interrupted a running process. It doesn't need
+            // a SIGCONT to wake up, just a clean detach.
+            LOGV("injection complete, applying GKI workaround and detaching");
+            return detach_with_gki_workaround(pid, 0);  // 0 means don't inject any signal
+        } else {
+            LOGV("injection complete, starting signal continuation sequence");
 
-        // 2. Send SIGCONT to the process
-        if (kill(pid, SIGCONT) == -1) {
-            PLOGE("kill(SIGCONT) on PID %d", pid);
-            BAIL_AND_DETACH
-        }
+            // 2. Send SIGCONT to the process
+            if (kill(pid, SIGCONT) == -1) {
+                PLOGE("kill(SIGCONT) on PID %d", pid);
+                BAIL_AND_DETACH
+            }
 
-        // 3. Resume (PTRACE_CONT)
-        if (ptrace(PTRACE_CONT, pid, 0, 0) == -1) {
-            PLOGE("ptrace(PTRACE_CONT) failed");
-            BAIL_AND_DETACH
-        }
-        if (!wait_for_process(pid, &status)) return false;
-
-        // 4. Expect SIGTRAP (caused by the signal interruption in Seize mode)
-        if (STOPPED_WITH(SIGTRAP, PTRACE_EVENT_STOP)) {
+            // 3. Resume (PTRACE_CONT)
             if (ptrace(PTRACE_CONT, pid, 0, 0) == -1) {
+                PLOGE("ptrace(PTRACE_CONT) failed");
                 BAIL_AND_DETACH
             }
             if (!wait_for_process(pid, &status)) return false;
 
-            // 5. Expect the actual SIGCONT delivery
-            if (STOPPED_WITH(SIGCONT, 0)) {
-                LOGV("received expected SIGCONT");
-                // 6. Workaround + Detach
-                return detach_with_gki_workaround(pid, SIGCONT);
+            // 4. Expect SIGTRAP (caused by the signal interruption in Seize mode)
+            if (STOPPED_WITH(SIGTRAP, PTRACE_EVENT_STOP)) {
+                if (ptrace(PTRACE_CONT, pid, 0, 0) == -1) {
+                    BAIL_AND_DETACH
+                }
+                if (!wait_for_process(pid, &status)) return false;
+
+                // 5. Expect the actual SIGCONT delivery
+                if (STOPPED_WITH(SIGCONT, 0)) {
+                    LOGV("received expected SIGCONT");
+                    // 6. Workaround + Detach
+                    return detach_with_gki_workaround(pid, SIGCONT);
+                } else {
+                    LOGE("unexpected state after SIGTRAP: %s", parse_status(status).c_str());
+                    BAIL_AND_DETACH
+                }
             } else {
-                LOGE("unexpected state after SIGTRAP: %s", parse_status(status).c_str());
+                LOGE("expected SIGTRAP after CONT, got: %s", parse_status(status).c_str());
                 BAIL_AND_DETACH
             }
-        } else {
-            LOGE("expected SIGTRAP after CONT, got: %s", parse_status(status).c_str());
-            BAIL_AND_DETACH
         }
     } else {
         LOGE("seize attached, but unexpected initial state: %s", parse_status(status).c_str());
@@ -426,7 +486,7 @@ static bool trace_with_seize(int pid) {
 
 // --- Strategy 2: PTRACE_ATTACH (Fallback) ---
 
-static bool trace_with_attach(int pid) {
+static bool trace_with_attach(int pid, bool is_standalone) {
     LOGI("falling back to trace_attach on PID %d", pid);
 
     // Classic attach. This sends SIGSTOP to the process immediately.
@@ -445,11 +505,13 @@ static bool trace_with_attach(int pid) {
     // Classic ATTACH results in a STOPPED status with SIGSTOP.
     // It does NOT use PTRACE_EVENT_STOP in the status bits usually.
     if (WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP) {
-        // Optional: Set EXITKILL for parity with SEIZE, though not strictly required for fallback.
-        ptrace(PTRACE_SETOPTIONS, pid, 0, PTRACE_O_EXITKILL);
+        if (!is_standalone) {
+            // Set EXITKILL for parity with SEIZE
+            ptrace(PTRACE_SETOPTIONS, pid, 0, PTRACE_O_EXITKILL);
+        }
 
         // 1. Inject Payload
-        if (!perform_injection(pid)) {
+        if (!perform_injection(pid, is_standalone)) {
             ptrace(PTRACE_DETACH, pid, 0, 0);
             return false;
         }
@@ -475,14 +537,14 @@ static bool trace_with_attach(int pid) {
  * Tries modern PTRACE_SEIZE first. If that fails with I/O error (EIO),
  * falls back to classic PTRACE_ATTACH.
  *
- * @param pid The Zygote process ID.
  * @return True on success, false on failure.
  */
-bool trace_zygote(int pid) {
-    LOGI("attaching to zygote (PID: %d) to begin injection", pid);
+bool trace_zygote(int pid, bool is_standalone) {
+    LOGI("attaching to zygote (PID: %d) to begin injection (standalone: %s)", pid,
+         is_standalone ? "true" : "false");
 
     // 1. Try SEIZE (Modern, robust handling of group stops)
-    if (trace_with_seize(pid)) {
+    if (trace_with_seize(pid, is_standalone)) {
         LOGI("successfully detached from zygote (via SEIZE), NeoZygisk active");
         return true;
     }
@@ -493,7 +555,7 @@ bool trace_zygote(int pid) {
     if (errno == EIO) {
         LOGW("PTRACE_SEIZE failed with EIO, attempting fallback to PTRACE_ATTACH");
 
-        if (trace_with_attach(pid)) {
+        if (trace_with_attach(pid, is_standalone)) {
             LOGI("successfully detached from zygote (via ATTACH), NeoZygisk active");
             return true;
         }

--- a/module/src/post-fs-data.sh
+++ b/module/src/post-fs-data.sh
@@ -24,6 +24,7 @@ create_sys_perm() {
 	mkdir -p $1
 	chmod 555 $1
 	chcon u:object_r:system_file:s0 $1
+	chown system:system $1
 }
 
 TMP_PATH=@WORK_DIRECTORY@
@@ -38,12 +39,14 @@ if [ -f $MODDIR/lib64/libzygisk.so ]; then
 	create_sys_perm $TMP_PATH/lib64
 	cp $MODDIR/lib64/libzygisk.so $TMP_PATH/lib64/libzygisk.so
 	chcon u:object_r:system_file:s0 $TMP_PATH/lib64/libzygisk.so
+	chown system:system $TMP_PATH/lib64/libzygisk.so
 fi
 
 if [ -f $MODDIR/lib/libzygisk.so ]; then
 	create_sys_perm $TMP_PATH/lib
 	cp $MODDIR/lib/libzygisk.so $TMP_PATH/lib/libzygisk.so
 	chcon u:object_r:system_file:s0 $TMP_PATH/lib/libzygisk.so
+	chown system:system $TMP_PATH/lib/libzygisk.so
 fi
 
 [ "$DEBUG" = true ] && export RUST_BACKTRACE=1
@@ -60,5 +63,4 @@ else
 	elif [ -f $MODDIR/bin/zygisk-ptrace32 ]; then
 		$MODDIR/bin/zygisk-ptrace32 trace $(pidof zygote32) --standalone &
 	fi
-	$MODDIR/bin/zygisk-ptrace64 trace $(pidof system_server) --system_server &
 fi

--- a/module/src/post-fs-data.sh
+++ b/module/src/post-fs-data.sh
@@ -2,54 +2,62 @@
 
 MODDIR=${0%/*}
 if [ "$ZYGISK_ENABLED" ]; then
-  exit 0
+	exit 0
 fi
 
 cd "$MODDIR"
 
 if [ "$(which magisk)" ]; then
-  for file in ../*; do
-    if [ -d "$file" ] && [ -d "$file/zygisk" ] && ! [ -f "$file/disable" ]; then
-      if [ -f "$file/post-fs-data.sh" ]; then
-        cd "$file"
-        log -p i -t "zygisk-sh" "Manually trigger post-fs-data.sh for $file"
-        sh "$(realpath ./post-fs-data.sh)"
-        cd "$MODDIR"
-      fi
-    fi
-  done
+	for file in ../*; do
+		if [ -d "$file" ] && [ -d "$file/zygisk" ] && ! [ -f "$file/disable" ]; then
+			if [ -f "$file/post-fs-data.sh" ]; then
+				cd "$file"
+				log -p i -t "zygisk-sh" "Manually trigger post-fs-data.sh for $file"
+				sh "$(realpath ./post-fs-data.sh)"
+				cd "$MODDIR"
+			fi
+		fi
+	done
 fi
 
 create_sys_perm() {
-  mkdir -p $1
-  chmod 555 $1
-  chcon u:object_r:system_file:s0 $1
+	mkdir -p $1
+	chmod 555 $1
+	chcon u:object_r:system_file:s0 $1
 }
 
 TMP_PATH=@WORK_DIRECTORY@
 
 if [ -d $TMP_PATH ]; then
-  rm -rf $TMP_PATH
+	rm -rf $TMP_PATH
 fi
 
 create_sys_perm $TMP_PATH
 
-if [ -f $MODDIR/lib64/libzygisk.so ];then
-  create_sys_perm $TMP_PATH/lib64
-  cp $MODDIR/lib64/libzygisk.so $TMP_PATH/lib64/libzygisk.so
-  chcon u:object_r:system_file:s0 $TMP_PATH/lib64/libzygisk.so
+if [ -f $MODDIR/lib64/libzygisk.so ]; then
+	create_sys_perm $TMP_PATH/lib64
+	cp $MODDIR/lib64/libzygisk.so $TMP_PATH/lib64/libzygisk.so
+	chcon u:object_r:system_file:s0 $TMP_PATH/lib64/libzygisk.so
 fi
 
-if [ -f $MODDIR/lib/libzygisk.so ];then
-  create_sys_perm $TMP_PATH/lib
-  cp $MODDIR/lib/libzygisk.so $TMP_PATH/lib/libzygisk.so
-  chcon u:object_r:system_file:s0 $TMP_PATH/lib/libzygisk.so
+if [ -f $MODDIR/lib/libzygisk.so ]; then
+	create_sys_perm $TMP_PATH/lib
+	cp $MODDIR/lib/libzygisk.so $TMP_PATH/lib/libzygisk.so
+	chcon u:object_r:system_file:s0 $TMP_PATH/lib/libzygisk.so
 fi
 
 [ "$DEBUG" = true ] && export RUST_BACKTRACE=1
 
-if [ -f $MODDIR/bin/zygisk-ptrace64 ];then
-$MODDIR/bin/zygisk-ptrace64 monitor &
-elif [ -f $MODDIR/bin/zygisk-ptrace32 ];then
-$MODDIR/bin/zygisk-ptrace32 monitor &
+if [ -z $(pidof system_server) ]; then
+	if [ -f $MODDIR/bin/zygisk-ptrace64 ]; then
+		$MODDIR/bin/zygisk-ptrace64 monitor &
+	elif [ -f $MODDIR/bin/zygisk-ptrace32 ]; then
+		$MODDIR/bin/zygisk-ptrace32 monitor &
+	fi
+else
+	if [ -f $MODDIR/bin/zygisk-ptrace64 ]; then
+		$MODDIR/bin/zygisk-ptrace64 trace $(pidof zygote64) --standalone &
+	elif [ -f $MODDIR/bin/zygisk-ptrace32 ]; then
+		$MODDIR/bin/zygisk-ptrace32 trace $(pidof zygote32) --standalone &
+	fi
 fi

--- a/module/src/post-fs-data.sh
+++ b/module/src/post-fs-data.sh
@@ -60,4 +60,5 @@ else
 	elif [ -f $MODDIR/bin/zygisk-ptrace32 ]; then
 		$MODDIR/bin/zygisk-ptrace32 trace $(pidof zygote32) --standalone &
 	fi
+	$MODDIR/bin/zygisk-ptrace64 trace $(pidof system_server) --system_server &
 fi

--- a/module/src/service.sh
+++ b/module/src/service.sh
@@ -9,20 +9,26 @@ fi
 
 cd "$MODDIR"
 
+system_server_pid=$(pidof system_server)
+
 if [ "$(which magisk)" ]; then
 	for file in ../*; do
 		if [ -d "$file" ] && [ -d "$file/zygisk" ] && ! [ -f "$file/disable" ]; then
 			if [ -f "$file/service.sh" ]; then
 				cd "$file"
 				log -p i -t "zygisk-sh" "Manually trigger service.sh for $file"
-				sh "$(realpath ./service.sh)" &
+				if [ -z $system_server_pid ]; then
+					sh "$(realpath ./service.sh)" &
+				else
+					sh "$(realpath ./service.sh)" --late-inject &
+				fi
 				cd "$MODDIR"
 			fi
 		fi
 	done
 fi
 
-if [ ! -z $(pidof system_server) ]; then
-	log -p i -t "zygisk-sh" "Maually inject into system_server $(pidof system_server)"
-	./bin/zygisk-ptrace64 trace $(pidof system_server) --system_server
+if [ ! -z $system_server_pid ]; then
+	log -p i -t "zygisk-sh" "Maually inject into system_server $system_server_pid"
+	./bin/zygisk-ptrace64 trace $system_server_pid --system_server
 fi

--- a/module/src/service.sh
+++ b/module/src/service.sh
@@ -2,22 +2,27 @@
 
 DEBUG=@DEBUG@
 
-MODDIR=${0%/*}
+MODDIR="$(dirname "$(realpath "$0")")"
 if [ "$ZYGISK_ENABLED" ]; then
-  exit 0
+	exit 0
 fi
 
 cd "$MODDIR"
 
 if [ "$(which magisk)" ]; then
-  for file in ../*; do
-    if [ -d "$file" ] && [ -d "$file/zygisk" ] && ! [ -f "$file/disable" ]; then
-      if [ -f "$file/service.sh" ]; then
-        cd "$file"
-        log -p i -t "zygisk-sh" "Manually trigger service.sh for $file"
-        sh "$(realpath ./service.sh)" &
-        cd "$MODDIR"
-      fi
-    fi
-  done
+	for file in ../*; do
+		if [ -d "$file" ] && [ -d "$file/zygisk" ] && ! [ -f "$file/disable" ]; then
+			if [ -f "$file/service.sh" ]; then
+				cd "$file"
+				log -p i -t "zygisk-sh" "Manually trigger service.sh for $file"
+				sh "$(realpath ./service.sh)" &
+				cd "$MODDIR"
+			fi
+		fi
+	done
+fi
+
+if [ ! -z $(pidof system_server) ]; then
+	log -p i -t "zygisk-sh" "Maually inject into system_server $(pidof system_server)"
+	./bin/zygisk-ptrace64 trace $(pidof system_server) --system_server
 fi

--- a/zygiskd/src/utils.rs
+++ b/zygiskd/src/utils.rs
@@ -160,7 +160,14 @@ pub fn unix_listener_from_path(path: &str) -> Result<UnixListener> {
     let socket = socket(AddressFamily::UNIX, SocketType::STREAM, None)?;
     bind(&socket, &addr)?;
     listen(&socket, 10)?; // Backlog of 10
+    // Label the socket so the zygote domain may connect on enforcing-SELinux devices.
     Command::new("chcon").arg("u:object_r:zygisk_file:s0").arg(path).status()?;
+    // World-accessible (0777) — this matches the permission observed on the control socket
+    // of shipped NeoZygisk releases on-device. The open DAC mode is intentional and not a
+    // gate: on enforcing devices access is controlled by the SELinux `zygisk_file` label,
+    // and in all cases the daemon authenticates peers with SO_PEERCRED (see
+    // `handle_connection` in zygiskd.rs), rejecting any connector that is not root or
+    // system. It also lets a late-injected system_server (AID_SYSTEM) reach the socket.
     Command::new("chmod").arg("777").arg(path).status()?;
     Ok(UnixListener::from(socket))
 }

--- a/zygiskd/src/utils.rs
+++ b/zygiskd/src/utils.rs
@@ -79,12 +79,6 @@ pub fn get_current_attr() -> Result<String> {
     Ok(s.trim().to_string())
 }
 
-/// Changes the SELinux context of a file using the `chcon` command.
-pub fn chcon(path: &str, context: &str) -> Result<()> {
-    Command::new("chcon").arg(context).arg(path).status()?;
-    Ok(())
-}
-
 /// Retrieves an Android system property value.
 pub fn get_property(name: &str) -> Result<String> {
     let name = CString::new(name)?;
@@ -166,7 +160,8 @@ pub fn unix_listener_from_path(path: &str) -> Result<UnixListener> {
     let socket = socket(AddressFamily::UNIX, SocketType::STREAM, None)?;
     bind(&socket, &addr)?;
     listen(&socket, 10)?; // Backlog of 10
-    chcon(path, "u:object_r:zygisk_file:s0")?;
+    Command::new("chcon").arg("u:object_r:zygisk_file:s0").arg(path).status()?;
+    Command::new("chmod").arg("777").arg(path).status()?;
     Ok(UnixListener::from(socket))
 }
 

--- a/zygiskd/src/zygiskd.rs
+++ b/zygiskd/src/zygiskd.rs
@@ -80,6 +80,35 @@ pub fn main() -> Result<()> {
 
 /// Handles a single incoming connection from Zygisk.
 fn handle_connection(mut stream: UnixStream, context: Arc<AppContext>) -> Result<()> {
+    // Kernel-verified peer admission.
+    //
+    // Every connection the daemon legitimately accepts is opened while the caller is
+    // still root or system at connect() time:
+    //   - zygote (uid 0) during injection and the whole pre-specialization window
+    //     (ReadModules, GetProcessFlags, CacheMountNamespace, UpdateMountNamespace via
+    //     the hooked unshare(), and the companion request);
+    //   - system_server (uid 1000) on the late-injection path;
+    //   - the root tracer (uid 0) for ZygoteRestart.
+    // The loader makes no daemon connection after a process drops to its app uid, and the
+    // app<->companion channel is a handed-off fd that never re-enters this accept path. So
+    // any connection presenting another uid is illegitimate. SO_PEERCRED is captured by the
+    // kernel at connect() time and cannot be spoofed, so we reject such peers here.
+    const AID_ROOT: u32 = 0;
+    const AID_SYSTEM: u32 = 1000;
+    match rustix::net::sockopt::socket_peercred(&stream) {
+        Ok(cred) => {
+            let uid = cred.uid.as_raw();
+            if uid != AID_ROOT && uid != AID_SYSTEM {
+                warn!("Rejecting daemon connection from untrusted peer: {:?}", cred);
+                return Ok(());
+            }
+        }
+        Err(e) => {
+            warn!("Rejecting daemon connection: cannot read peer credentials: {}", e);
+            return Ok(());
+        }
+    }
+
     let action = stream.read_u8()?;
     let action = DaemonSocketAction::try_from(action)
         .with_context(|| format!("Invalid daemon action code: {}", action))?;


### PR DESCRIPTION
This commit introduces the --standalone flag to the zygisk-ptrace64 binary, enabling the initialization of NeoZygisk after the zygote process has already started. This provides an alternative to relying strictly on Magisk's init phase injection.

To support injecting into an active, running process, several structural adjustments were made to the injection flow:

CLI and Daemon Initialization:
- The trace command now parses the --standalone flag, which is mutually exclusive with --restart.
- In standalone mode, the tracer resolves and changes the working directory to the module directory, then initializes the daemon controller prior to injection. This ensures the UNIX domain sockets are listening before the injected library attempts to connect.
- Added SIGINT and SIGTERM handlers to safely detach and send SIGCONT to zygote if the tracer is aborted by the user, preventing system lockups.

Ptrace Flow Adjustments:
- Omitted PTRACE_O_EXITKILL in standalone mode to ensure the zygote process is not terminated if the tracer exits unexpectedly.
- Updated the PTRACE_SEIZE strategy to explicitly issue PTRACE_INTERRUPT. Unlike standard Magisk mode where zygote is already suspended via SIGSTOP, a running process must be manually interrupted.
- Handled the resulting SIGTRAP stop and bypassed the SIGCONT wake-up sequence during detach, as a clean detach is sufficient to resume a process stopped via PTRACE_INTERRUPT.

Injection Logic:
- Extracted the remote code execution sequence (dlopen, dlsym, entry) into a shared function to maintain DRY principles.
- Created inject_standalone to bypass the AT_ENTRY stack parsing and memory hijacking. Since the dynamic linker is already initialized, the payload is invoked immediately.
- Implemented a cross-architecture syscall restart mitigation. Interrupting a tracee inside a blocking system call (e.g., epoll_wait) and altering the instruction pointer triggers the kernel's ERESTARTSYS rewind logic, causing the instruction pointer to jump into invalid padding and throw a SIGTRAP. This is resolved by clearing orig_rax (and architecture equivalents) in the temporary registers before the remote call, while preserving the actual system call state in the backup registers for a seamless resumption.