### PR TITLE
Refine SELinux rules for sock connection

### DIFF
--- a/module/src/sepolicy.rule
+++ b/module/src/sepolicy.rule
@@ -3,7 +3,7 @@ typeattribute zygisk_file mlstrustedobject
 allow zygote zygisk_file sock_file {read write}
 
 allow zygote magisk lnk_file read
-allow zygote unlabeled file {read open}
+allow zygote unlabeled {file sock_file} *
 allow zygote zygote capability sys_chroot
 allow zygote su dir search
 allow zygote su {lnk_file file} read


### PR DESCRIPTION
It is reported on Samsung device [samsung/infinity_beyond1lte/beyond1lte:16/BP4A.251205.006/eng.androi.20260317.090127:userdebug/release-keys] that, the following SELinux rule is needed:
```
avc:  denied  { write } for  comm="app_process64" name="cp64.sock" dev="dm-41" ino=... scontext=u:r:zygote:s0 tcontext=u:object_r:unlabeled:s0 tclass=sock_file permissive=0
```