### PR TITLE
Enforce least privilege and harden workflow security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,6 +24,7 @@ jobs:
         with:
           submodules: "recursive"
           fetch-depth: 0 # Needed for versioning from git history
+          persist-credentials: false
 
       - name: Setup Java
         uses: actions/setup-java@v5


### PR DESCRIPTION
- Explicitly set top-level permissions to 'contents: read' to follow security best practices.
- Set 'persist-credentials: false' in the checkout step to prevent the GITHUB_TOKEN from being stored on the runner disk.

I have now also set `Read repository contents and packages permissions` for project settings `Workflow permissions`.