### PR TITLE
Fix SIGILL during remote execution by clearing PSTATE.BTYPE on AArch64

### DIFF
--- a/loader/src/ptracer/ptracer.cpp
+++ b/loader/src/ptracer/ptracer.cpp
@@ -184,7 +184,18 @@ bool inject_on_main(int pid, const char *lib_path) {
     }
 
     // Backup the current registers before we start making remote calls.
+    // It is vital we keep the original PSTATE intact in the backup, so
+    // the original executable can securely validate its own BTI pad upon final resume.
     memcpy(&backup, &regs, sizeof(regs));
+
+#if defined(__aarch64__)
+    // Clear the BTYPE field (bits 10 and 11) in PSTATE.
+    // The previous indirect branch from the linker set BTYPE to 0b11.
+    // If we jump into BTI-protected bionic libraries (like libdl.so) with BTYPE=0b11,
+    // the CPU will throw a Branch Target Exception (SIGILL).
+    regs.pstate &= ~(3ULL << 10);
+#endif
+
     map = MapInfo::Scan(std::to_string(pid));  // Re-scan maps as they may have changed.
     auto local_map = MapInfo::Scan();
     auto libc_return_addr = find_module_return_addr(map, "libc.so");


### PR DESCRIPTION
During the entry point hijack phase on ARMv9 hardware with Branch Target Identification (BTI) enabled, dispatching remote calls to bionic functions (such as `dlopen`) resulted in an immediate Branch Target Exception (SIGILL).

This crash is caused by a stale Branch Type (`BTYPE`) state. When the Android dynamic linker transfers control to the target's `AT_ENTRY`, it uses an indirect branch instruction (`BR`). This hardware action updates the CPU's `PSTATE` register, setting the `BTYPE` field to `0b11` (Indirect Jump).

When the tracer pauses the process and redirects execution to `dlopen`, the CPU inherits this `PSTATE`. Modern Android bionic libraries are compiled with BTI and start with `PACIASP` or `BTI c` landing pads. These landing pads strictly require the incoming `BTYPE` to be `0b01` (Direct Call) or `0b10` (Indirect Call). Confronted with `0b11`, the CPU assumes a JOP (Jump-Oriented Programming) exploit and raises a SIGILL.

This commit resolves the issue by clearing the `BTYPE` field (bits 10 and 11) in the `pstate` register structure prior to initiating any remote calls. Resetting the field to `0b00` prevents the hardware from enforcing BTI validation on the immediate next instruction. The original `PSTATE` is preserved in the register backup, ensuring that the target executable can securely validate its own BTI landing pad when execution is fully restored.

References: https://developer.android.com/ndk/guides/abis#armv9_enabling_pac_and_bti_for_cc