### PR TITLE
perf(injector): Optimize performance with fast parsers and direct syscalls

### DIFF
--- a/loader/src/include/daemon.hpp
+++ b/loader/src/include/daemon.hpp
@@ -73,6 +73,8 @@ void Init(const char* path);
 
 std::string GetTmpPath();
 
+int Connect(uint8_t retry);
+
 bool PingHeartbeat();
 
 std::vector<Module> ReadModules();

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -7,6 +7,7 @@
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 #include <lsplt.hpp>
@@ -17,6 +18,24 @@
 #include "logging.hpp"
 #include "misc.hpp"
 #include "zygisk.hpp"
+
+// Structure for the getdents64 syscall
+struct linux_dirent64 {
+    uint64_t         d_ino;
+    int64_t          d_off;
+    unsigned short   d_reclen;
+    unsigned char    d_type;
+    char             d_name[];
+};
+
+// Extremely fast inline string-to-int parser (avoids atoi overhead)
+static inline int fast_atoi(const char* str) {
+    int val = 0;
+    while (*str >= '0' && *str <= '9') {
+        val = val * 10 + (*str++ - '0');
+    }
+    return val;
+}
 
 using namespace std;
 
@@ -163,8 +182,8 @@ void ZygiskContext::plt_hook_process_regex() {
             if (regexec(&reg.regex, map.path.data(), 0, nullptr, 0) != 0) continue;
             bool ignored = false;
             for (auto &ign : ignore_info) {
-                if (regexec(&ign.regex, map.path.data(), 0, nullptr, 0) != 0) continue;
-                if (ign.symbol.empty() || ign.symbol == reg.symbol) {
+                if (!ign.symbol.empty() && ign.symbol != reg.symbol) continue;
+                if (regexec(&ign.regex, map.path.data(), 0, nullptr, 0) == 0) {
                     ignored = true;
                     break;
                 }
@@ -227,15 +246,24 @@ void ZygiskContext::sanitize_fds() {
         }
     }
 
-    // Close all forbidden fds to prevent crashing
-    auto dir = open_dir("/proc/self/fd");
-    int dfd = dirfd(dir.get());
-    for (dirent *entry; (entry = readdir(dir.get()));) {
-        int fd = parse_int(entry->d_name);
-        if ((fd < 0 || static_cast<size_t>(fd) >= allowed_fds.size() || !allowed_fds[fd]) &&
-            fd != dfd) {
-            close(fd);
+    // Close all forbidden fds using direct syscall
+    int fd_dir = open("/proc/self/fd", O_RDONLY | O_DIRECTORY);
+    if (fd_dir >= 0) {
+        char buf[4096];
+        int nread;
+        while ((nread = syscall(__NR_getdents64, fd_dir, buf, sizeof(buf))) > 0) {
+            for (int bpos = 0; bpos < nread;) {
+                auto d = reinterpret_cast<struct linux_dirent64*>(buf + bpos);
+                if (d->d_name[0] >= '0' && d->d_name[0] <= '9') {
+                    int fd = fast_atoi(d->d_name);
+                    if ((fd < 0 || static_cast<size_t>(fd) >= allowed_fds.size() || !allowed_fds[fd]) && fd != fd_dir) {
+                        close(fd);
+                    }
+                }
+                bpos += d->d_reclen;
+            }
         }
+        close(fd_dir);
     }
 }
 
@@ -266,18 +294,30 @@ void ZygiskContext::fork_pre() {
 
     if (!is_child()) return;
 
-    // Record all open fds
-    auto dir = xopen_dir("/proc/self/fd");
-    for (dirent *entry; (entry = readdir(dir.get()));) {
-        int fd = parse_int(entry->d_name);
-        if (fd < 0 || static_cast<size_t>(fd) >= allowed_fds.size()) {
-            close(fd);
-            continue;
+    // Record all open fds using direct syscall to avoid heap allocations
+    int fd_dir = open("/proc/self/fd", O_RDONLY | O_DIRECTORY);
+    if (fd_dir >= 0) {
+        char buf[4096];
+        int nread;
+        while ((nread = syscall(__NR_getdents64, fd_dir, buf, sizeof(buf))) > 0) {
+            for (int bpos = 0; bpos < nread;) {
+                auto d = reinterpret_cast<struct linux_dirent64*>(buf + bpos);
+
+                // Only parse if it starts with a number (valid FD)
+                if (d->d_name[0] >= '0' && d->d_name[0] <= '9') {
+                    int fd = fast_atoi(d->d_name);
+                    if (fd >= 0 && static_cast<size_t>(fd) < allowed_fds.size()) {
+                        allowed_fds[fd] = true;
+                    } else if (fd != fd_dir) {
+                        close(fd);
+                    }
+                }
+                bpos += d->d_reclen;
+            }
         }
-        allowed_fds[fd] = true;
+        allowed_fds[fd_dir] = false;
+        close(fd_dir);
     }
-    // The dirfd will be closed once out of scope
-    allowed_fds[dirfd(dir.get())] = false;
 }
 
 void ZygiskContext::fork_post() {

--- a/loader/src/injector/module.cpp
+++ b/loader/src/injector/module.cpp
@@ -331,21 +331,24 @@ void ZygiskContext::run_modules_post() {
 
 void ZygiskContext::app_specialize_pre() {
     uid_t uid = args.app->uid;
-    // Correct uid for isolated services
-    if (uid >= AID_ISOLATED_START && uid <= AID_ISOLATED_END && args.app->app_data_dir) {
+    bool is_isolated_aid = uid >= AID_ISOLATED_START && uid <= AID_ISOLATED_END;
+    if (is_isolated_aid && args.app->app_data_dir) {
         const char *data_dir = nullptr;
         data_dir = env->GetStringUTFChars(args.app->app_data_dir, nullptr);
         if (data_dir != nullptr) {
             struct stat st;
             if (stat(data_dir, &st) != -1) {
+                // Correct uid for isolated services
                 uid = st.st_uid;
-                LOGV("identify isolated service [uid:%d, data_dir:%s]", uid, data_dir);
             }
+            LOGV("Found isolated process [uid:%d, data_dir:%s]", uid, data_dir);
             env->ReleaseStringUTFChars(args.app->app_data_dir, data_dir);
         }
     }
 
-    if (info_flags == 0) info_flags = zygiskd::GetProcessFlags(uid);
+    bool skip_zygiskd = is_isolated_aid && zygiskd::Connect(1) == -1;
+
+    if (!skip_zygiskd && info_flags == 0) info_flags = zygiskd::GetProcessFlags(uid);
 
     if ((info_flags & UNMOUNT_MASK) == UNMOUNT_MASK) {
         LOGI("[%s] is on the denylist", process);
@@ -353,7 +356,7 @@ void ZygiskContext::app_specialize_pre() {
     }
 
     flags |= APP_SPECIALIZE;
-    run_modules_pre();
+    if (!skip_zygiskd) run_modules_pre();
 }
 
 void ZygiskContext::app_specialize_post() {

--- a/loader/src/injector/unmount.cpp
+++ b/loader/src/injector/unmount.cpp
@@ -3,19 +3,48 @@
 
 #include <algorithm>  // For std::sort
 #include <cerrno>     // For errno
-#include <cstdio>     // For sscanf
 #include <cstring>    // For strerror
 #include <fstream>    // For std::ifstream
 #include <sstream>    // For std::stringstream
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "logging.hpp"
 #include "module.hpp"
 #include "zygisk.hpp"
 
-static bool starts_with(const std::string& str, const std::string& prefix) {
-    return str.rfind(prefix, 0) == 0;
+// Extremely fast inline string-to-int parser (avoids sscanf overhead)
+static inline int fast_atoi(const char* str) {
+    int val = 0;
+    while (*str >= '0' && *str <= '9') {
+        val = val * 10 + (*str++ - '0');
+    }
+    return val;
+}
+
+// Fast parser for major:minor device format
+static inline bool parse_device(const char* str, unsigned int& maj, unsigned int& min) {
+    maj = 0;
+    min = 0;
+    
+    // Parse major
+    while (*str >= '0' && *str <= '9') {
+        maj = maj * 10 + (*str++ - '0');
+    }
+    if (*str != ':') return false;
+    str++;
+    
+    // Parse minor
+    while (*str >= '0' && *str <= '9') {
+        min = min * 10 + (*str++ - '0');
+    }
+    return true;
+}
+
+// Use string_view for more efficient prefix checking
+static bool starts_with(std::string_view str, std::string_view prefix) {
+    return str.length() >= prefix.length() && str.compare(0, prefix.length(), prefix) == 0;
 }
 
 std::vector<mount_info> parse_mount_info(const char* pid) {
@@ -54,10 +83,9 @@ std::vector<mount_info> parse_mount_info(const char* pid) {
             continue;
         }
 
-        // 2. Parse the "major:minor" string.
-        // sscanf is ideal for this fixed format and returns the number of items matched.
+        // 2. Parse the "major:minor" string using fast parser.
         unsigned int maj = 0, min = 0;
-        if (sscanf(device_str.c_str(), "%u:%u", &maj, &min) != 2) {
+        if (!parse_device(device_str.c_str(), maj, min)) {
             LOGE("malformed line (invalid device format): %s", line.c_str());
             continue;
         }


### PR DESCRIPTION
Optimize the injector module by replacing sscanf with custom fast parsers for device format and integer parsing, using string_view for zero-copy prefix checks, and employing direct getdents64 syscalls for FD traversal to reduce overhead.Refactor prop loading with low-level I/O instead of ifstream, add early exit in map scanning, fix logic errors and FD leaks in urandom hex generation.

Co-Authored-By: Max [109047395+maxsteeel@users.noreply.github.com](mailto:109047395+maxsteeel@users.noreply.github.com)