### PR TITLE
fix(zygisk): stop leaking TMP_PATH to app processes

### DIFF
--- a/loader/src/common/daemon.cpp
+++ b/loader/src/common/daemon.cpp
@@ -12,7 +12,6 @@ static std::string TMP_PATH;
 
 void Init(const char *path) {
     TMP_PATH = path;
-    setenv("TMP_PATH", TMP_PATH.data(), 0);
 }
 
 std::string GetTmpPath() { return TMP_PATH; }
@@ -23,7 +22,7 @@ int Connect(uint8_t retry) {
         .sun_family = AF_UNIX,
         .sun_path = {0},
     };
-    auto socket_path = TMP_PATH + kCPSocketName;
+    auto socket_path = GetTmpPath() + kCPSocketName;
     strcpy(addr.sun_path, socket_path.c_str());
     socklen_t socklen = sizeof(addr);
 

--- a/loader/src/ptracer/zygote_abi.cpp
+++ b/loader/src/ptracer/zygote_abi.cpp
@@ -5,6 +5,7 @@
 
 #include <csignal>
 
+#include "daemon.hpp"
 #include "logging.hpp"
 #include "monitor.hpp"
 #include "utils.hpp"
@@ -49,7 +50,13 @@ bool ZygoteAbiManager::ensure_daemon_created() {
         if (pid == 0) {
             std::string daemon_name = "./bin/zygiskd";
             daemon_name += abi_name_;
-            execl(daemon_name.c_str(), daemon_name.c_str(), nullptr);
+            execl(
+                daemon_name.c_str(),
+                daemon_name.c_str(),
+                "--workdir",
+                zygiskd::GetTmpPath().c_str(),
+                nullptr
+            );
             PLOGE("exec daemon %s", daemon_name.c_str());
             exit(1);
         }

--- a/zygiskd/src/main.rs
+++ b/zygiskd/src/main.rs
@@ -66,6 +66,7 @@
 //!
 //! This binary has multiple modes of operation based on its command-line arguments:
 //! - No arguments: Starts the main `zygiskd` daemon.
+//! - `--workdir <path>`: Starts the main `zygiskd` daemon with an explicit work directory.
 //! - `companion <fd>`: Starts a companion process for a Zygisk module.
 //! - `version`: Prints the daemon version.
 //! - `root`: Detects and prints the current root implementation.
@@ -112,9 +113,18 @@ fn start() {
             root_impl::setup();
             println!("Detected root implementation: {:?}", root_impl::get());
         }
+        Some("--workdir") => {
+            if let Some(tmp_path) = args.get(2) {
+                if let Err(e) = main_daemon_entry(Some(tmp_path)) {
+                    error!("Zygiskd daemon failed: {:?}", e);
+                }
+            } else {
+                error!("Daemon: Missing work directory argument.");
+            }
+        }
         _ => {
-            // Default to starting the main daemon.
-            if let Err(e) = main_daemon_entry() {
+            // Default to starting the main daemon with the legacy environment-based workdir path.
+            if let Err(e) = main_daemon_entry(None) {
                 error!("Zygiskd daemon failed: {:?}", e);
             }
         }
@@ -123,13 +133,13 @@ fn start() {
 
 /// The main entry point for the Zygisk daemon.
 /// It sets up the environment and launches the core daemon logic.
-fn main_daemon_entry() -> anyhow::Result<()> {
+fn main_daemon_entry(tmp_path: Option<&str>) -> anyhow::Result<()> {
     // We must be in the root mount namespace to function correctly.
     mount::switch_mount_namespace(1)?;
     // Detect and globally set the root implementation.
     root_impl::setup();
     log::info!("Current root implementation: {:?}", root_impl::get());
-    zygiskd::main()
+    zygiskd::main(tmp_path)
 }
 
 fn main() {

--- a/zygiskd/src/main.rs
+++ b/zygiskd/src/main.rs
@@ -65,8 +65,10 @@
 //! 10. **Direct Connection:** The companion receives the file descriptor and now holds the other end of the app's original socket. It can now communicate directly with the app. The daemon's brokering job is complete, and it is no longer involved in their conversation. This handoff is efficient and seamless from the app's perspective.
 //!
 //! This binary has multiple modes of operation based on its command-line arguments:
-//! - No arguments: Starts the main `zygiskd` daemon.
-//! - `--workdir <path>`: Starts the main `zygiskd` daemon with an explicit work directory.
+//! - No arguments: Starts the main `zygiskd` daemon, taking its work directory
+//!   from the `TMP_PATH` environment variable.
+//! - `--workdir <path>`: Starts the main `zygiskd` daemon with an explicit work
+//!   directory, bypassing the `TMP_PATH` environment variable.
 //! - `companion <fd>`: Starts a companion process for a Zygisk module.
 //! - `version`: Prints the daemon version.
 //! - `root`: Detects and prints the current root implementation.
@@ -113,18 +115,16 @@ fn start() {
             root_impl::setup();
             println!("Detected root implementation: {:?}", root_impl::get());
         }
-        Some("--workdir") => {
-            if let Some(tmp_path) = args.get(2) {
-                if let Err(e) = main_daemon_entry(Some(tmp_path)) {
-                    error!("Zygiskd daemon failed: {:?}", e);
-                }
-            } else {
-                error!("Daemon: Missing work directory argument.");
-            }
-        }
         _ => {
-            // Default to starting the main daemon with the legacy environment-based workdir path.
-            if let Err(e) = main_daemon_entry(None) {
+            // Default mode: the main daemon. It accepts an optional `--workdir <path>`
+            // option carrying the work directory; absent that, it falls back to the
+            // TMP_PATH environment variable (see `initialize_globals`).
+            let workdir = args
+                .iter()
+                .position(|arg| arg == "--workdir")
+                .and_then(|i| args.get(i + 1))
+                .map(String::as_str);
+            if let Err(e) = main_daemon_entry(workdir) {
                 error!("Zygiskd daemon failed: {:?}", e);
             }
         }

--- a/zygiskd/src/zygiskd.rs
+++ b/zygiskd/src/zygiskd.rs
@@ -50,10 +50,10 @@ static CONTROLLER_SOCKET: OnceLock<String> = OnceLock::new();
 static DAEMON_SOCKET_PATH: OnceLock<String> = OnceLock::new();
 
 /// The main function for the zygiskd daemon.
-pub fn main() -> Result<()> {
+pub fn main(tmp_path: Option<&str>) -> Result<()> {
     info!("Welcome to NeoZygisk ({}) !", ZKSU_VERSION);
 
-    initialize_globals()?;
+    initialize_globals(tmp_path)?;
     let modules = load_modules()?;
     send_startup_info(&modules)?;
 
@@ -148,9 +148,13 @@ fn handle_threaded_action(
     }
 }
 
-/// Initializes global path variables from the environment.
-fn initialize_globals() -> Result<()> {
-    let tmp_path = std::env::var("TMP_PATH").context("TMP_PATH environment variable not set")?;
+/// Initializes global path variables from the daemon work directory.
+fn initialize_globals(tmp_path: Option<&str>) -> Result<()> {
+    let tmp_path = match tmp_path {
+        Some(path) if !path.is_empty() => path.to_owned(),
+        Some(_) => bail!("TMP_PATH daemon argument is empty"),
+        None => std::env::var("TMP_PATH").context("TMP_PATH environment variable not set")?,
+    };
     TMP_PATH.set(tmp_path).unwrap();
 
     CONTROLLER_SOCKET

--- a/zygiskd/src/zygiskd.rs
+++ b/zygiskd/src/zygiskd.rs
@@ -151,8 +151,10 @@ fn handle_threaded_action(
 /// Initializes global path variables from the daemon work directory.
 fn initialize_globals(tmp_path: Option<&str>) -> Result<()> {
     let tmp_path = match tmp_path {
+        // The normal path: the loader passes the work directory via `--workdir`.
         Some(path) if !path.is_empty() => path.to_owned(),
         Some(_) => bail!("TMP_PATH daemon argument is empty"),
+        // Escape hatch for manual invocation without `--workdir`.
         None => std::env::var("TMP_PATH").context("TMP_PATH environment variable not set")?,
     };
     TMP_PATH.set(tmp_path).unwrap();


### PR DESCRIPTION
NeoZygisk used TMP_PATH both as internal loader state and as inherited process environment for zygiskd startup. That exposed a stable TMP_PATH marker inside injected zygote and app processes while also tying daemon bootstrap to inherited environment state.

This change keeps TMP_PATH as internal loader state, removes TMP_PATH export from injected processes, and lets zygiskd take an explicit --workdir argument when the internal launcher needs to pass the daemon work directory without relying on environment inheritance. The default daemon entry path remains compatible, while internal socket and workdir resolution continue to use GetTmpPath().