### PR TITLE
Add late-load.sh for KernelSU LKM late-load mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,13 @@ To configure the DenyList for a specific application, use the appropriate settin
 > **Important Note for Magisk Users**
 >
 > The **`Enforce DenyList`** option in Magisk enables Magisk's *own* DenyList implementation. This is separate from NeoZygisk's functionality, is not guaranteed to hide all mount-related traces, and may conflict with NeoZygisk's hiding mechanisms. It is strongly recommended to leave this option disabled and rely solely on NeoZygisk's configuration.
+
+## KernelSU LKM late-load (jailbreak mode)
+
+On KernelSU setups where the kernel module is loaded after boot (`ksud late-load`, sometimes called jailbreak mode), `post-fs-data.sh` is **not** executed. NeoZygisk ships a `late-load.sh` script for this path: it bootstraps the ptrace monitor via `post-fs-data.sh` when needed, then soft-reboots zygote so injection applies to new processes.
+
+This script runs automatically when you trigger late-load from the KernelSU manager. No manual setup is required after flashing NeoZygisk.
+
+> **Note**
+>
+> The zygote restart causes a brief System UI reload (similar to a soft reboot). Apps already running before late-load must be restarted to receive Zygisk injection.

--- a/module/build.gradle.kts
+++ b/module/build.gradle.kts
@@ -55,7 +55,7 @@ androidComponents.onVariants { variant ->
         into(moduleDir)
         from("${rootProject.projectDir}/README.md")
         from("$projectDir/src") {
-            exclude("module.prop", "action.sh", "customize.sh", "post-fs-data.sh", "service.sh", "uninstall.sh", "zygisk-ctl.sh")
+            exclude("module.prop", "action.sh", "customize.sh", "post-fs-data.sh", "late-load.sh", "service.sh", "uninstall.sh", "zygisk-ctl.sh")
             filter<FixCrLfFilter>("eol" to FixCrLfFilter.CrLf.newInstance("lf"))
         }
         from("$projectDir/src") {
@@ -69,7 +69,7 @@ androidComponents.onVariants { variant ->
             )
         }
         from("$projectDir/src") {
-            include("action.sh", "customize.sh", "post-fs-data.sh", "service.sh", "uninstall.sh", "zygisk-ctl.sh")
+            include("action.sh", "customize.sh", "post-fs-data.sh", "late-load.sh", "service.sh", "uninstall.sh", "zygisk-ctl.sh")
             val tokens = mapOf(
                 "DEBUG" to if (buildTypeLowered == "debug") "true" else "false",
                 "MIN_APATCH_VERSION" to "$minAPatchVersion",

--- a/module/src/customize.sh
+++ b/module/src/customize.sh
@@ -105,11 +105,12 @@ if [ "$KSU" ]; then
 fi
 
 ui_print "- Extracting module files"
-extract "$ZIPFILE" 'action.sh'     "$MODPATH"
+extract "$ZIPFILE" 'action.sh'       "$MODPATH"
 extract "$ZIPFILE" 'module.prop'     "$MODPATH"
 extract "$ZIPFILE" 'post-fs-data.sh' "$MODPATH"
+extract "$ZIPFILE" 'late-load.sh'    "$MODPATH"
 extract "$ZIPFILE" 'service.sh'      "$MODPATH"
-extract "$ZIPFILE" 'uninstall.sh'      "$MODPATH"
+extract "$ZIPFILE" 'uninstall.sh'    "$MODPATH"
 mv "$TMPDIR/sepolicy.rule" "$MODPATH"
 
 mkdir "$MODPATH/bin"

--- a/module/src/late-load.sh
+++ b/module/src/late-load.sh
@@ -1,0 +1,28 @@
+#!/system/bin/sh
+
+MODDIR=${0%/*}
+
+if [ "$ZYGISK_ENABLED" ]; then
+  exit 0
+fi
+
+cd "$MODDIR"
+
+# INFO: KernelSU LKM late-load (ksud late-load) skips post-fs-data.sh.
+#         Bootstrap NeoZygisk when the ptrace monitor is not running yet.
+monitor_running() {
+  pidof zygisk-ptrace64 >/dev/null 2>&1 && return 0
+  pidof zygisk-ptrace32 >/dev/null 2>&1 && return 0
+  return 1
+}
+
+if ! monitor_running; then
+  sh "$MODDIR/post-fs-data.sh"
+  sleep 1
+fi
+
+# INFO: Zygote started before root was available; restart it so NeoZygisk
+#         injects into new app processes (soft reboot, not a full reboot).
+killall zygote64 zygote 2>/dev/null
+
+exit 0


### PR DESCRIPTION
```
Add late-load.sh for KernelSU LKM late-load (jailbreak mode)
```

## Summary

- Add `module/src/late-load.sh` for KernelSU `ksud late-load` / LKM jailbreak mode
- Package `late-load.sh` in `customize.sh` and `module/build.gradle.kts`
- Document late-load behavior in README

## Why

KernelSU LKM setups load `kernelsu.ko` after the system has booted (`ksud late-load`). In this mode, **`post-fs-data.sh` is never run** — only `late-load.sh` ([KernelSU module docs](https://kernelsu.org/guide/module.html#late-load-mode)).

NeoZygisk currently has no `late-load.sh`, so users on jailbreak-style KernelSU installs get no Zygisk injection until they manually run `post-fs-data.sh` and restart zygote.

This PR ships that workflow:

1. Bootstrap NeoZygisk via `post-fs-data.sh` if the ptrace monitor is not running
2. Soft-reboot zygote (`killall zygote64 zygote`) so new processes receive injection

## Test plan

- [x] Cold boot without jailbreak: NeoZygisk inactive (expected)
- [x] Tap 越狱 (ksud late-load): `late-load.sh` runs, monitor starts
- [x] Module status shows ptrace monitor / injection active after zygote restart
- [x] Zygisk-dependent modules (e.g. Vector) work in newly started apps

## Notes

- `late-load.sh` only runs during KernelSU late-load; normal boot still uses `post-fs-data.sh`
- Uses `pidof` instead of `pgrep -f` for toybox/busybox compatibility
- Intentionally avoids live `zygisk-ptrace64 trace` on a running zygote (can SIGKILL zygote on failure)
```